### PR TITLE
fix: enable git push flows with array

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,6 +99,7 @@ dependencies {
 
     // test
     testImplementation "org.junit.jupiter:junit-jupiter-engine"
+    testImplementation "org.junit.jupiter:junit-jupiter-params"
     testImplementation "org.hamcrest:hamcrest"
     testImplementation "org.hamcrest:hamcrest-library"
 }

--- a/src/main/java/io/kestra/plugin/git/AbstractPushTask.java
+++ b/src/main/java/io/kestra/plugin/git/AbstractPushTask.java
@@ -317,7 +317,7 @@ public abstract class AbstractPushTask<O extends AbstractPushTask.Output> extend
                     yield  Collections.singletonList(renderedValue);
                 }
             }
-            default -> null;
+            case null, default -> null;
         };
 
         Map<Path, Supplier<InputStream>> contentByPath = this.instanceResourcesContentByPath(runContext, localGitDirectory, globs);


### PR DESCRIPTION
Check if flows is of type array after rendering.
Added unit test to test a string pebble expression that will render an array and the legacy behavior with a list of pebble string.
#99
