### PR TITLE
fix: exception when namespace is null

### DIFF
--- a/src/main/java/io/kestra/plugin/git/PushDashboards.java
+++ b/src/main/java/io/kestra/plugin/git/PushDashboards.java
@@ -103,7 +103,7 @@ public class PushDashboards extends AbstractPushTask<PushDashboards.Output> {
 
     @Override
     public Property<String> fetchedNamespace() {
-        return null;
+        return Property.of("");
     }
 
     protected Map<Path, Supplier<InputStream>> instanceResourcesContentByPath(RunContext runContext, Path flowDirectory, List<String> globs) throws IllegalVariableEvaluationException {

--- a/src/main/java/io/kestra/plugin/git/SyncDashboards.java
+++ b/src/main/java/io/kestra/plugin/git/SyncDashboards.java
@@ -96,7 +96,7 @@ public class SyncDashboards extends AbstractSyncTask<Dashboard, SyncDashboards.O
 
     @Override
     public Property<String> fetchedNamespace() {
-        return null;
+        return Property.of("");
     }
 
     @Override


### PR DESCRIPTION
Exception thrown is `Cannot invoke "String.split(String)" because "namespace" is null`
Fixed when putting empty namespace for dashboards
