### PR TITLE
feat(git): add SyncFlow task for single flow sync

### DIFF
--- a/src/main/java/io/kestra/plugin/git/SyncFlow.java
+++ b/src/main/java/io/kestra/plugin/git/SyncFlow.java
@@ -1,0 +1,125 @@
+package io.kestra.plugin.git;
+
+import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.models.tasks.RunnableTask;
+import io.kestra.core.runners.DefaultRunContext;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.services.FlowService;
+import io.kestra.plugin.git.services.GitService;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.apache.commons.io.IOUtils;
+import org.eclipse.jgit.api.Git;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@SuperBuilder(toBuilder = true)
+@ToString
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor
+@Schema(
+    title = "Sync a single flow from a Git repository to a Kestra namespace."
+)
+@Plugin(
+    examples = {
+        @Example(
+            title = "Sync a single flow from a Git repository to a specific namespace. This can be used to deploy or update individual flows.",
+            full = true,
+            code = """
+                id: sync_single_flow_from_git
+                namespace: system.cicd
+
+                tasks:
+                  - id: sync_my_flow
+                    type: io.kestra.plugin.git.SyncFlow
+                    url: https://github.com/my-org/kestra-flows
+                    branch: main
+                    username: my_git_username
+                    password: "{{ secret('GITHUB_ACCESS_TOKEN') }}"
+                    targetNamespace: dev.marketing # required
+                    flowPath: "flows/marketing/flow.yml" # required
+                """
+        )
+    }
+)
+public class SyncFlow extends AbstractGitTask implements RunnableTask<SyncFlow.Output> {
+
+    public static final Pattern NAMESPACE_FINDER_PATTERN = Pattern.compile("(?m)^\\s*namespace:\\s*(.*)$");
+
+    @Schema(title = "The branch to clone from.")
+    @Builder.Default
+    private Property<String> branch = Property.of("main");
+
+    @Override
+    public Property<String> getBranch() {
+        return this.branch;
+    }
+
+    @Schema(title = "The target namespace where the flow will be synced.")
+    @NotNull
+    private Property<String> targetNamespace;
+
+    @Schema(title = "The full path to the flow YAML file within the Git repository.")
+    @NotNull
+    private Property<String> flowPath;
+
+    @Schema(title = "If true, the task will only log the action without actually syncing the flow.")
+    @Builder.Default
+    private Property<Boolean> dryRun = Property.of(Boolean.FALSE);
+
+    @Override
+    public Output run(RunContext runContext) throws Exception {
+        GitService gitService = new GitService(this);
+        FlowService flowService = ((DefaultRunContext) runContext).getApplicationContext().getBean(FlowService.class);
+
+        Git git = gitService.cloneBranch(runContext, runContext.render(this.getBranch()).as(String.class).orElse(null), Property.of(Boolean.FALSE));
+        Path cloneDir = git.getRepository().getWorkTree().toPath();
+
+        String renderedFlowPath = runContext.render(this.flowPath).as(String.class).orElseThrow();
+        Path flowFilePath = cloneDir.resolve(renderedFlowPath);
+
+        if (!Files.exists(flowFilePath)) {
+            throw new java.io.FileNotFoundException("Flow file not found at path: " + renderedFlowPath);
+        }
+
+        String renderedNamespace = runContext.render(this.targetNamespace).as(String.class).orElseThrow();
+        String flowSource;
+        try (InputStream is = Files.newInputStream(flowFilePath)) {
+            flowSource = IOUtils.toString(is, StandardCharsets.UTF_8);
+        }
+
+        Matcher matcher = NAMESPACE_FINDER_PATTERN.matcher(flowSource);
+        flowSource = matcher.replaceFirst("namespace: " + renderedNamespace);
+
+        Flow flow = flowService.importFlow(runContext.flowInfo().tenantId(), flowSource.stripTrailing(), runContext.render(this.dryRun).as(Boolean.class).orElse(Boolean.FALSE));
+
+        git.close();
+
+        return Output.builder()
+            .flowId(flow.getId())
+            .namespace(flow.getNamespace())
+            .revision(flow.getRevision())
+            .build();
+    }
+
+    @SuperBuilder
+    @Getter
+    public static class Output implements io.kestra.core.models.tasks.Output {
+        @Schema(title = "The ID of the synced flow.")
+        private final String flowId;
+        @Schema(title = "The namespace of the synced flow.")
+        private final String namespace;
+        @Schema(title = "The new revision number of the flow.")
+        private final Integer revision;
+    }
+}

--- a/src/main/java/io/kestra/plugin/git/SyncFlows.java
+++ b/src/main/java/io/kestra/plugin/git/SyncFlows.java
@@ -4,7 +4,6 @@ import io.kestra.core.exceptions.FlowProcessingException;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
-import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.FlowWithException;
 import io.kestra.core.models.flows.FlowWithSource;

--- a/src/test/java/io/kestra/plugin/git/SyncFlowTest.java
+++ b/src/test/java/io/kestra/plugin/git/SyncFlowTest.java
@@ -1,0 +1,165 @@
+package io.kestra.plugin.git;
+
+import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.flows.FlowWithSource;
+import io.kestra.core.models.flows.GenericFlow;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.repositories.FlowRepositoryInterface;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.tenant.TenantService;
+import io.kestra.core.junit.annotations.KestraTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+@KestraTest
+public class SyncFlowTest extends AbstractGitTest {
+    public static final String BRANCH = "sync";
+    public static final String TENANT_ID = TenantService.MAIN_TENANT;
+    public static final String TARGET_NAMESPACE = "io.kestra.synced";
+
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    @Inject
+    private FlowRepositoryInterface flowRepositoryInterface;
+
+    @BeforeEach
+    void init() {
+        flowRepositoryInterface.findAllForAllTenants().forEach(f -> {
+            flowRepositoryInterface.delete(FlowWithSource.of(f, ""));
+        });
+    }
+
+    @Test
+    void createNewFlow() throws Exception {
+        RunContext runContext = runContext();
+
+        assertThat(flowRepositoryInterface.findAllForAllTenants().size(), is(0));
+
+        SyncFlow task = SyncFlow.builder()
+            .url(new Property<>("{{url}}"))
+            .username(new Property<>("{{pat}}"))
+            .password(new Property<>("{{pat}}"))
+            .branch(new Property<>("{{branch}}"))
+            .targetNamespace(new Property<>(TARGET_NAMESPACE))
+            .flowPath(new Property<>("to_clone/_flows/first-flow.yml"))
+            .build();
+
+        SyncFlow.Output output = task.run(runContext);
+
+        assertThat(output.getFlowId(), is("first-flow"));
+        assertThat(output.getNamespace(), is(TARGET_NAMESPACE));
+        assertThat(output.getRevision(), is(1));
+
+        List<Flow> flows = flowRepositoryInterface.findAllForAllTenants();
+        assertThat(flows, hasSize(1));
+
+        Flow syncedFlow = flows.getFirst();
+        assertThat(syncedFlow.getId(), is("first-flow"));
+        assertThat(syncedFlow.getNamespace(), is(TARGET_NAMESPACE));
+        assertThat(syncedFlow.getRevision(), is(1));
+    }
+
+    @Test
+    void updateExistingFlow() throws Exception {
+        RunContext runContext = runContext();
+
+        String initialSource = "id: second-flow\nnamespace: " + TARGET_NAMESPACE + "\ntasks:\n  - id: log\n    type: io.kestra.core.tasks.log.Log\n    message: 'v1'";
+        GenericFlow flow = GenericFlow.fromYaml(TENANT_ID, initialSource);
+
+        flowRepositoryInterface.create(
+            flow.toBuilder().source(initialSource).build()
+        );
+
+        Flow initialFlow = flowRepositoryInterface.findAllForAllTenants().get(0);
+        assertThat(initialFlow.getRevision(), is(1));
+
+        SyncFlow task = SyncFlow.builder()
+            .url(new Property<>("{{url}}"))
+            .username(new Property<>("{{pat}}"))
+            .password(new Property<>("{{pat}}"))
+            .branch(new Property<>("{{branch}}"))
+            .targetNamespace(new Property<>(TARGET_NAMESPACE))
+            .flowPath(new Property<>("to_clone/_flows/second-flow.yml"))
+            .build();
+
+        SyncFlow.Output output = task.run(runContext);
+
+        assertThat(output.getRevision(), is(2));
+
+        List<FlowWithSource> flowsWithSource = flowRepositoryInterface.findByNamespacePrefixWithSource(TENANT_ID, TARGET_NAMESPACE);
+        assertThat(flowsWithSource, hasSize(1));
+
+        FlowWithSource updatedFlowWithSource = flowsWithSource.getFirst();
+
+        assertThat(updatedFlowWithSource.getId(), is("second-flow"));
+        assertThat(updatedFlowWithSource.getRevision(), is(2));
+        assertThat(updatedFlowWithSource.getSource(), containsString("Hello from second-flow"));
+    }
+
+    @Test
+    void dryRun() throws Exception {
+        RunContext runContext = runContext();
+
+        assertThat(flowRepositoryInterface.findAllForAllTenants().size(), is(0));
+
+        SyncFlow task = SyncFlow.builder()
+            .url(new Property<>("{{url}}"))
+            .username(new Property<>("{{pat}}"))
+            .password(new Property<>("{{pat}}"))
+            .branch(new Property<>("{{branch}}"))
+            .targetNamespace(new Property<>(TARGET_NAMESPACE))
+            .flowPath(new Property<>("to_clone/_flows/first-flow.yml"))
+            .dryRun(Property.of(true))
+            .build();
+
+        SyncFlow.Output output = task.run(runContext);
+
+        assertThat(output.getFlowId(), is("first-flow"));
+        assertThat(output.getNamespace(), is(TARGET_NAMESPACE));
+        assertThat(output.getRevision(), is(1));
+
+        assertThat(flowRepositoryInterface.findAllForAllTenants().size(), is(0));
+    }
+
+    @Test
+    void fileNotFound() {
+        RunContext runContext = runContext();
+
+        SyncFlow task = SyncFlow.builder()
+            .url(new Property<>("{{url}}"))
+            .username(new Property<>("{{pat}}"))
+            .password(new Property<>("{{pat}}"))
+            .branch(new Property<>("{{branch}}"))
+            .targetNamespace(new Property<>(TARGET_NAMESPACE))
+            .flowPath(new Property<>("non_existent_file.yml"))
+            .build();
+
+        Exception exception = org.junit.jupiter.api.Assertions.assertThrows(
+            java.io.FileNotFoundException.class,
+            () -> task.run(runContext)
+        );
+        assertThat(exception.getMessage(), containsString("non_existent_file.yml"));
+    }
+
+    private RunContext runContext() {
+        return runContextFactory.of(Map.of(
+            "flow", Map.of(
+                "tenantId", TENANT_ID,
+                "namespace", "io.kestra.unittest",
+                "id", "test-flow"
+            ),
+            "url", repositoryUrl,
+            "pat", pat,
+            "branch", BRANCH
+        ));
+    }
+}


### PR DESCRIPTION
Adds a new task `io.kestra.plugin.git.SyncFlow` to allow syncing a single flow from a Git repository to a target Kestra namespace.

closes kestra-io/kestra-ee#3997