### PR TITLE
feat(): add support to push execution files

### DIFF
--- a/src/main/java/io/kestra/plugin/git/AbstractPushTask.java
+++ b/src/main/java/io/kestra/plugin/git/AbstractPushTask.java
@@ -401,6 +401,13 @@ public abstract class AbstractPushTask<O extends AbstractPushTask.Output> extend
         }
 
         var workTree = git.getRepository().getWorkTree().toPath().toRealPath();
+
+        if (contentByPath.isEmpty()) {
+            runContext.logger().info("No content to push - skipping Git operations.");
+            git.close();
+            return output(Output.builder().build(), null);
+        }
+
         AddCommand add = git.add();
 
         for (Path p : contentByPath.keySet()) {

--- a/src/main/java/io/kestra/plugin/git/PushExecutionFiles.java
+++ b/src/main/java/io/kestra/plugin/git/PushExecutionFiles.java
@@ -11,6 +11,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import org.eclipse.jgit.api.Git;
 
 import java.io.FileInputStream;
 import java.io.InputStream;
@@ -55,9 +56,9 @@ import static io.kestra.core.utils.Rethrow.throwSupplier;
 
                   - id: push
                     type: io.kestra.plugin.git.PushExecutionFiles
-                       files:
-                         - "*.csv"
-                         - "*.json"
+                    files:
+                      - "*.csv"
+                      - "*.json"
                     gitDirectory: analytics
                     url: https://github.com/company/data-pipeline
                     username: git_user

--- a/src/main/java/io/kestra/plugin/git/PushExecutionFiles.java
+++ b/src/main/java/io/kestra/plugin/git/PushExecutionFiles.java
@@ -119,8 +119,13 @@ public class PushExecutionFiles extends AbstractPushTask<PushExecutionFiles.Outp
     private Object files;
 
     @Schema(
-        title = "Explicit file map of target filename to execution file URI",
-        description = "Useful when pushing files from other tasks' outputs, which expose URIs."
+        title = "A map of key-value pairs where the key is the filename and the value is the URI of the file to upload.",
+        description = "This should be a map of URI, with the key being the filename that will be upload and the value is the URI." +
+            "This property is intended to be used with the output files of other tasks. Many Kestra tasks, incl. all Downloads tasks, " +
+            "output a map of files so that you can directly pass the output property to this task e.g. " +
+            "[outputFiles in the S3 Downloads task](https://kestra.io/plugins/plugin-aws/tasks/s3/io.kestra.plugin.aws.s3.downloads#outputfiles) " +
+            "or the [files in the Archive Decompress task](https://kestra.io/plugins/plugin-compress/tasks/io.kestra.plugin.compress.archivedecompress#files).",
+        anyOf = {Map.class, String.class}
     )
     private Object filesMap;
 
@@ -132,7 +137,7 @@ public class PushExecutionFiles extends AbstractPushTask<PushExecutionFiles.Outp
     )
     @Override
     public Property<String> getCommitMessage() {
-        return Optional.ofNullable(this.commitMessage).orElse(new Property<>("Add execution files"));
+        return Optional.ofNullable(this.commitMessage).orElse(new Property<>("Add files from execution {{ execution.id }}"));
     }
 
     @Override
@@ -176,7 +181,6 @@ public class PushExecutionFiles extends AbstractPushTask<PushExecutionFiles.Outp
 
         return super.run(runContext);
     }
-
 
     @Override
     @SuppressWarnings("unchecked")
@@ -237,7 +241,7 @@ public class PushExecutionFiles extends AbstractPushTask<PushExecutionFiles.Outp
             if (failIfMissing) {
                 throw new IllegalArgumentException("Either files or filesMap must be provided");
             } else {
-                runContext.logger().warn("No files or filesMap provided — skipping push.");
+                runContext.logger().warn("No files or filesMap provided - skipping push.");
                 return Map.of();
             }
         }

--- a/src/main/java/io/kestra/plugin/git/PushExecutionFiles.java
+++ b/src/main/java/io/kestra/plugin/git/PushExecutionFiles.java
@@ -57,8 +57,7 @@ import static io.kestra.core.utils.Rethrow.throwSupplier;
                   - id: push
                     type: io.kestra.plugin.git.PushExecutionFiles
                     files:
-                      - "*.csv"
-                      - "*.json"
+                      - "*.txt"
                     gitDirectory: analytics
                     url: https://github.com/company/data-pipeline
                     username: git_user
@@ -92,7 +91,6 @@ import static io.kestra.core.utils.Rethrow.throwSupplier;
                     password: "{{ secret('GITHUB_TOKEN') }}"
                     branch: logs
                     commitMessage: "Archive log for run {{ execution.id }}"
-
                 """
         )
     }
@@ -164,18 +162,13 @@ public class PushExecutionFiles extends AbstractPushTask<PushExecutionFiles.Outp
             renderedGlobs
         );
 
-
         if (contentByPath.isEmpty()) {
             Boolean failIfMissing = runContext.render(this.errorOnMissing).as(Boolean.class).orElse(false);
             if (failIfMissing) {
                 throw new IllegalArgumentException("No files matched the provided patterns: " + this.files);
             } else {
                 runContext.logger().info("No files to push, skipping Git operations.");
-                return Output.builder()
-                    .commitId(null)
-                    .commitURL(null)
-                    .files(null)
-                    .build();
+                return Output.builder().build();
             }
         }
 

--- a/src/main/java/io/kestra/plugin/git/PushExecutionFiles.java
+++ b/src/main/java/io/kestra/plugin/git/PushExecutionFiles.java
@@ -11,7 +11,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
-import org.eclipse.jgit.api.Git;
 
 import java.io.FileInputStream;
 import java.io.InputStream;
@@ -156,15 +155,11 @@ public class PushExecutionFiles extends AbstractPushTask<PushExecutionFiles.Outp
             case null, default -> List.of();
         };
 
-        Map<Path, Supplier<InputStream>> contentByPath = this.instanceResourcesContentByPath(
-            runContext,
-            runContext.workingDir().path(),
-            renderedGlobs
-        );
+        Map<Path, Supplier<InputStream>> contentByPath = this.instanceResourcesContentByPath(runContext, runContext.workingDir().path(), renderedGlobs);
 
         if (contentByPath.isEmpty()) {
-            Boolean failIfMissing = runContext.render(this.errorOnMissing).as(Boolean.class).orElse(false);
-            if (failIfMissing) {
+            var rFailIfMissing = runContext.render(this.errorOnMissing).as(Boolean.class).orElse(false);
+            if (rFailIfMissing) {
                 throw new IllegalArgumentException("No files matched the provided patterns: " + this.files);
             } else {
                 runContext.logger().info("No files to push, skipping Git operations.");
@@ -183,7 +178,7 @@ public class PushExecutionFiles extends AbstractPushTask<PushExecutionFiles.Outp
         if (filesMap != null) {
             Map<String, Object> readFilesMap;
             if (filesMap instanceof String stringValue) {
-                String rendered = runContext.render(stringValue);
+                var rendered = runContext.render(stringValue);
                 readFilesMap = JacksonMapper.ofJson().readValue(rendered, Map.class);
             } else {
                 readFilesMap = (Map<String, Object>) filesMap;
@@ -257,14 +252,10 @@ public class PushExecutionFiles extends AbstractPushTask<PushExecutionFiles.Outp
             }
         }
 
-
         if (contentByPath.isEmpty()) {
-            Boolean failIfMissing = runContext.render(this.errorOnMissing).as(Boolean.class).orElse(false);
+            var failIfMissing = runContext.render(this.errorOnMissing).as(Boolean.class).orElse(false);
             if (failIfMissing) {
                 throw new IllegalArgumentException("No files matched the provided patterns: " + globs);
-            } else {
-                runContext.logger().info("No execution files matched patterns {}, skipping push.", globs);
-                return Map.of();
             }
         }
 

--- a/src/main/java/io/kestra/plugin/git/PushExecutionFiles.java
+++ b/src/main/java/io/kestra/plugin/git/PushExecutionFiles.java
@@ -1,0 +1,279 @@
+package io.kestra.plugin.git;
+
+import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.serializers.JacksonMapper;
+import io.kestra.core.utils.PathMatcherPredicate;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import static io.kestra.core.utils.Rethrow.throwFunction;
+import static io.kestra.core.utils.Rethrow.throwSupplier;
+
+@SuperBuilder(toBuilder = true)
+@NoArgsConstructor
+@Getter
+@Schema(
+    title = "Commit and push Execution Output Files to a Git repository.",
+    description = "This task pushes one or more files produced by a task execution directly to Git."
+)
+@Plugin(
+    examples = {
+        @Example(
+            title = "Push output files generated from task to Git",
+            full = true,
+            code = """
+                id: push_exec_files
+                namespace: company.team
+
+                tasks:
+                  - id: generate
+                    type: io.kestra.plugin.scripts.python.Script
+                    taskRunner:
+                      type: io.kestra.plugin.core.runner.Process
+                    outputFiles:
+                      - report.txt
+                    script: |
+                      with open("report.txt", "w") as f:
+                          f.write("Analysis done")
+
+                  - id: push
+                    type: io.kestra.plugin.git.PushExecutionFiles
+                       files:
+                         - "*.csv"
+                         - "*.json"
+                    gitDirectory: analytics
+                    url: https://github.com/company/data-pipeline
+                    username: git_user
+                    password: "{{ secret('GITHUB_TOKEN') }}"
+                    branch: data-reports
+                    commitMessage: "Add CSV and JSON reports {{ now() }}"
+                """
+        ),
+        @Example(
+            title = "Push and rename execution outputs using filesMap",
+            full = true,
+            code = """
+                id: push_with_map
+                namespace: company.logs
+
+                tasks:
+                  - id: generate
+                    type: io.kestra.plugin.scripts.shell.Script
+                    outputFiles:
+                      - "run.log"
+                    script: |
+                      echo "Run completed at $(date)" > run.log
+
+                  - id: push
+                    type: io.kestra.plugin.git.PushExecutionFiles
+                    filesMap:
+                      "run-{{ execution.id }}.log": "{{ outputs.generate.outputFiles['run.log'] }}"
+                    gitDirectory: logs
+                    url: https://github.com/company/log-archive
+                    username: git_user
+                    password: "{{ secret('GITHUB_TOKEN') }}"
+                    branch: logs
+                    commitMessage: "Archive log for run {{ execution.id }}"
+
+                """
+        )
+    }
+)
+public class PushExecutionFiles extends AbstractPushTask<PushExecutionFiles.Output> {
+    @Schema(
+        title = "The branch to which files should be committed and pushed",
+        description = "If the branch doesn’t exist yet, it will be created."
+    )
+    @Builder.Default
+    private Property<String> branch = Property.ofValue("main");
+
+    @Schema(
+        title = "Directory in the Git repository where files should be pushed",
+        description = "Defaults to `_outputs`."
+    )
+    @Builder.Default
+    private Property<String> gitDirectory = Property.ofValue("_outputs");
+
+    @Schema(
+        title = "Glob pattern(s) to select execution output files from the working directory",
+        description = "If provided, will match files relative to the execution working directory."
+    )
+    private Object files;
+
+    @Schema(
+        title = "Explicit file map of target filename to execution file URI",
+        description = "Useful when pushing files from other tasks' outputs, which expose URIs."
+    )
+    private Object filesMap;
+
+    @Builder.Default
+    private Property<Boolean> errorOnMissing = Property.ofValue(false);
+
+    @Schema(
+        title = "Git commit message"
+    )
+    @Override
+    public Property<String> getCommitMessage() {
+        return Optional.ofNullable(this.commitMessage).orElse(new Property<>("Add execution files"));
+    }
+
+    @Override
+    public Object globs() {
+        return this.files;
+    }
+
+    @Override
+    public Property<String> fetchedNamespace() {
+        return new Property<>("{{ flow.namespace }}");
+    }
+
+    @Override
+    public Output run(RunContext runContext) throws Exception {
+        List<String> renderedGlobs = switch (this.globs()) {
+            case List<?> globList -> ((List<String>) globList).stream().map(throwFunction(runContext::render)).toList();
+            case String globString -> List.of(runContext.render(globString));
+            case null, default -> List.of();
+        };
+
+        Map<Path, Supplier<InputStream>> contentByPath = this.instanceResourcesContentByPath(
+            runContext,
+            runContext.workingDir().path(),
+            renderedGlobs
+        );
+
+
+        if (contentByPath.isEmpty()) {
+            Boolean failIfMissing = runContext.render(this.errorOnMissing).as(Boolean.class).orElse(false);
+            if (failIfMissing) {
+                throw new IllegalArgumentException("No files matched the provided patterns: " + this.files);
+            } else {
+                runContext.logger().info("No files to push, skipping Git operations.");
+                return Output.builder()
+                    .commitId(null)
+                    .commitURL(null)
+                    .files(null)
+                    .build();
+            }
+        }
+
+        return super.run(runContext);
+    }
+
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Map<Path, Supplier<InputStream>> instanceResourcesContentByPath(RunContext runContext, Path baseDirectory, List<String> globs) throws Exception {
+        Map<Path, Supplier<InputStream>> contentByPath;
+
+        if (filesMap != null) {
+            Map<String, Object> readFilesMap;
+            if (filesMap instanceof String stringValue) {
+                String rendered = runContext.render(stringValue);
+                readFilesMap = JacksonMapper.ofJson().readValue(rendered, Map.class);
+            } else {
+                readFilesMap = (Map<String, Object>) filesMap;
+            }
+            Map<String, Object> renderedMap = runContext.render(readFilesMap);
+
+            contentByPath = renderedMap.entrySet().stream().collect(Collectors.toMap(
+                e -> baseDirectory.resolve(e.getKey()),
+                throwFunction(e -> throwSupplier(() -> {
+                    URI sourceFileURI = URI.create((String) e.getValue());
+                    return runContext.storage().getFile(sourceFileURI);
+                }))
+            ));
+        }
+        else if (globs != null && !globs.isEmpty()) {
+            Predicate<Path> matcher = PathMatcherPredicate.matches(globs);
+            List<Path> localMatches = runContext.workingDir().findAllFilesMatching(globs)
+                .stream()
+                .filter(matcher)
+                .toList();
+
+            if (!localMatches.isEmpty()) {
+                contentByPath = localMatches.stream().collect(Collectors.toMap(
+                    path -> baseDirectory.resolve(path.toString()),
+                    throwFunction(path -> throwSupplier(() -> new FileInputStream(path.toFile())))
+                ));
+            } else {
+                Map<String, Object> outputs = (Map<String, Object>) runContext.getVariables().get("outputs");
+                if (outputs != null) {
+                    contentByPath = outputs.values().stream()
+                        .filter(v -> v instanceof Map && ((Map<?, ?>) v).get("outputFiles") instanceof Map)
+                        .flatMap(v -> ((Map<String, Object>) ((Map<?, ?>) v).get("outputFiles")).entrySet().stream())
+                        .filter(e -> globs.stream().anyMatch(g -> e.getKey().matches(g.replace("*", ".*"))))
+                        .collect(Collectors.toMap(
+                            e -> baseDirectory.resolve(e.getKey()),
+                            throwFunction(e -> throwSupplier(() -> {
+                                URI sourceFileURI = URI.create((String) e.getValue());
+                                return runContext.storage().getFile(sourceFileURI);
+                            }))
+                        ));
+                } else {
+                    contentByPath = Map.of();
+                }
+            }
+        }
+        else {
+            Boolean failIfMissing = runContext.render(this.errorOnMissing).as(Boolean.class).orElse(false);
+            if (failIfMissing) {
+                throw new IllegalArgumentException("Either files or filesMap must be provided");
+            } else {
+                runContext.logger().warn("No files or filesMap provided — skipping push.");
+                return Map.of();
+            }
+        }
+
+        if (contentByPath.isEmpty()) {
+            Boolean failIfMissing = runContext.render(this.errorOnMissing).as(Boolean.class).orElse(false);
+            if (failIfMissing) {
+                throw new IllegalArgumentException("No files matched the provided patterns: " + globs);
+            } else {
+                runContext.logger().info("No execution files matched patterns {}, skipping push.", globs);
+                return Map.of();
+            }
+        }
+
+        return contentByPath;
+    }
+
+    @Override
+    protected Output output(AbstractPushTask.Output pushOutput, URI diffFileStorageUri) {
+        return Output.builder()
+            .commitId(pushOutput.getCommitId())
+            .commitURL(pushOutput.getCommitURL())
+            .files(diffFileStorageUri)
+            .build();
+    }
+
+    @SuperBuilder
+    @Getter
+    public static class Output extends AbstractPushTask.Output {
+        @Schema(
+            title = "A file containing all changes pushed (or not in case of dry run) to Git"
+        )
+        private URI files;
+
+        @Override
+        public URI diffFileUri() {
+            return this.files;
+        }
+    }
+}

--- a/src/test/java/io/kestra/plugin/git/PushExecutionFilesTest.java
+++ b/src/test/java/io/kestra/plugin/git/PushExecutionFilesTest.java
@@ -1,0 +1,259 @@
+package io.kestra.plugin.git;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.storages.StorageContext;
+import io.kestra.core.storages.StorageInterface;
+import io.kestra.core.tenant.TenantService;
+import io.kestra.core.utils.IdUtils;
+import io.kestra.plugin.git.services.GitService;
+import jakarta.inject.Inject;
+import org.apache.commons.io.FileUtils;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.transport.RefSpec;
+import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.eclipse.jgit.lib.Constants.R_HEADS;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+@KestraTest
+class PushExecutionFilesTest extends AbstractGitTest {
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    @Inject
+    private StorageInterface storage;
+
+    @Test
+    void pushSingleFileWithGlob() throws Exception {
+        String namespace = IdUtils.create().toLowerCase();
+        String branch = IdUtils.create();
+
+        Map<String, Object> outputs = Map.of(
+            "generate", Map.of(
+                "outputFiles", Map.of(
+                    "report.txt", "kestra://"
+                        + StorageContext.namespaceFilePrefix(namespace)
+                        + "/report.txt"
+                )
+            )
+        );
+
+        RunContext runContext = runContextFactory.of(Map.of(
+            "flow", Map.of(
+                "tenantId", TenantService.MAIN_TENANT,
+                "namespace", namespace
+            ),
+            "url", repositoryUrl,
+            "branch", branch,
+            "pat", pat,
+            "outputs", outputs
+        ));
+
+        String filePath = "report.txt";
+        String fileContent = "hello from storage";
+        storage.put(
+            TenantService.MAIN_TENANT,
+            namespace,
+            URI.create("kestra://" + StorageContext.namespaceFilePrefix(namespace) + "/" + filePath),
+            new ByteArrayInputStream(fileContent.getBytes(StandardCharsets.UTF_8))
+        );
+
+        PushExecutionFiles push = PushExecutionFiles.builder()
+            .id("push")
+            .type(PushExecutionFiles.class.getName())
+            .url(Property.ofExpression("{{ url }}"))
+            .username(Property.ofExpression("{{ pat }}"))
+            .password(Property.ofExpression("{{ pat }}"))
+            .branch(Property.ofExpression("{{ branch }}"))
+            .files("*.txt")
+            .gitDirectory(Property.ofValue("reports"))
+            .commitMessage(Property.ofValue("push test"))
+            .build();
+
+        try {
+            PushExecutionFiles.Output out = push.run(runContext);
+            assertThat(out.getCommitId(), notNullValue());
+
+            Clone clone = Clone.builder()
+                .id("clone")
+                .type(Clone.class.getName())
+                .url(new Property<>(repositoryUrl))
+                .username(new Property<>(pat))
+                .password(new Property<>(pat))
+                .branch(new Property<>(branch))
+                .build();
+
+            Clone.Output cloneOutput = clone.run(runContextFactory.of());
+            File pushedFile = new File(Path.of(cloneOutput.getDirectory(), "reports").toFile(), filePath);
+            assertThat(pushedFile.exists(), is(true));
+            assertThat(FileUtils.readFileToString(pushedFile, StandardCharsets.UTF_8), is(fileContent));
+        } finally {
+            deleteRemoteBranch(runContext.workingDir().path(), branch);
+        }
+    }
+
+    @Test
+    void pushFilesMapRenamed() throws Exception {
+        String namespace = IdUtils.create().toLowerCase();
+        String branch = IdUtils.create();
+
+        RunContext runContext = runContext(namespace, branch);
+
+        String filePath = "report.txt";
+        String fileContent = "log here";
+        var logURI = storage.put(
+            TenantService.MAIN_TENANT,
+            namespace,
+            URI.create("kestra://" + StorageContext.namespaceFilePrefix(namespace) + "/" + filePath),
+            new ByteArrayInputStream(fileContent.getBytes(StandardCharsets.UTF_8))
+        );
+
+        PushExecutionFiles push = PushExecutionFiles.builder()
+            .id("push")
+            .type(PushExecutionFiles.class.getName())
+            .url(Property.ofExpression("{{ url }}"))
+            .username(Property.ofExpression("{{ pat }}"))
+            .password(Property.ofExpression("{{ pat }}"))
+            .branch(Property.ofExpression("{{ branch }}"))
+            .filesMap(Map.of("renamed.log", logURI.toString()))
+            .gitDirectory(Property.ofValue("logs"))
+            .commitMessage(Property.ofValue("push log"))
+            .build();
+
+        try {
+            PushExecutionFiles.Output out = push.run(runContext);
+            assertThat(out.getCommitId(), notNullValue());
+
+            Clone clone = Clone.builder()
+                .id("clone")
+                .type(Clone.class.getName())
+                .url(new Property<>(repositoryUrl))
+                .username(new Property<>(pat))
+                .password(new Property<>(pat))
+                .branch(new Property<>(branch))
+                .build();
+
+            Clone.Output cloneOutput = clone.run(runContextFactory.of());
+            File pushedFile = new File(Path.of(cloneOutput.getDirectory(), "logs").toFile(), "renamed.log");
+            assertThat(pushedFile.exists(), is(true));
+            assertThat(FileUtils.readFileToString(pushedFile, StandardCharsets.UTF_8), is(fileContent));
+        } finally {
+            deleteRemoteBranch(runContext.workingDir().path(), branch);
+        }
+    }
+
+    @Test
+    void skipIfNoMatch() throws Exception {
+        String branch = IdUtils.create();
+        String namespace = IdUtils.create().toLowerCase();
+
+        RunContext runContext = runContext(namespace, branch);
+
+        PushExecutionFiles push = PushExecutionFiles.builder()
+            .id("push")
+            .type(PushExecutionFiles.class.getName())
+            .url(Property.ofExpression("{{ url }}"))
+            .username(Property.ofExpression("{{ pat }}"))
+            .password(Property.ofExpression("{{ pat }}"))
+            .branch(Property.ofExpression("{{ branch }}"))
+            .files("*.json")
+            .gitDirectory(Property.ofValue("reports"))
+            .commitMessage(Property.ofValue("skip test"))
+            .errorOnMissing(Property.ofValue(false))
+            .build();
+
+        try {
+            PushExecutionFiles.Output out = push.run(runContext);
+            assertThat(out.getCommitId(), nullValue());
+        } finally {
+            deleteRemoteBranch(runContext.workingDir().path(), branch);
+        }
+    }
+
+    @Test
+    void dryRunDoesNotPush() throws Exception {
+        String branch = IdUtils.create();
+        String namespace = IdUtils.create().toLowerCase();
+
+        RunContext runContext = runContext(namespace, branch);
+
+        String filePath = "file.csv";
+        String fileContent = "id,val\n1,2";
+        storage.put(
+            TenantService.MAIN_TENANT,
+            namespace,
+            URI.create("kestra://" + StorageContext.namespaceFilePrefix(namespace) + "/" + filePath),
+            new ByteArrayInputStream(fileContent.getBytes(StandardCharsets.UTF_8))
+        );
+
+        PushExecutionFiles push = PushExecutionFiles.builder()
+            .id("push")
+            .type(PushExecutionFiles.class.getName())
+            .url(Property.ofExpression("{{ url }}"))
+            .username(Property.ofExpression("{{ pat }}"))
+            .password(Property.ofExpression("{{ pat }}"))
+            .branch(Property.ofExpression("{{ branch }}"))
+            .files("*.csv")
+            .gitDirectory(Property.ofValue("reports"))
+            .commitMessage(Property.ofValue("dry run"))
+            .dryRun(Property.ofValue(true))
+            .build();
+
+        try {
+            PushExecutionFiles.Output out = push.run(runContext);
+            GitService svc = new GitService(push);
+            assertThat(svc.branchExists(runContext, branch), is(false));
+            assertThat(out.getCommitId(), nullValue());
+        } finally {
+            deleteRemoteBranch(runContext.workingDir().path(), branch);
+        }
+    }
+
+    private void deleteRemoteBranch(Path gitDirectory, String branchName) throws GitAPIException, IOException {
+        Path dotGit = gitDirectory.resolve(".git");
+        if (!Files.exists(dotGit)) {
+            return;
+        }
+        try (Git git = Git.open(gitDirectory.toFile())) {
+            git.checkout().setName("tmp").setCreateBranch(true).call();
+            git.branchDelete().setBranchNames(R_HEADS + branchName).call();
+            RefSpec refSpec = new RefSpec()
+                .setSource(null)
+                .setDestination(R_HEADS + branchName);
+            git.push()
+                .setCredentialsProvider(new UsernamePasswordCredentialsProvider(pat, pat))
+                .setRefSpecs(refSpec)
+                .setRemote("origin")
+                .call();
+        }
+    }
+
+    private RunContext runContext(String namespace, String branch) {
+        return runContextFactory.of(Map.of(
+            "flow", Map.of(
+                "tenantId", TenantService.MAIN_TENANT,
+                "namespace", namespace
+            ),
+            "url", repositoryUrl,
+            "branch", branch,
+            "pat", pat
+        ));
+    }
+
+}


### PR DESCRIPTION
closes #189 

```yaml
id: push_exec_files
namespace: company.team

tasks:
  - id: generate
    type: io.kestra.plugin.scripts.python.Script
    taskRunner:
      type: io.kestra.plugin.core.runner.Process
    outputFiles:
      - report.txt
    script: |
      with open("report.txt", "w") as f:
          f.write("Analysis done")

  - id: push
    type: io.kestra.plugin.git.PushExecutionFiles
    files:
      - "*.txt"
    gitDirectory: analytics
    url: https://github.com/company/data-pipeline
    username: git_user
    password: "{{ secret('GITHUB_TOKEN') }}"
    branch: data-reportsdsadas
    commitMessage: "Add reports {{ now() }}"
```

<img width="1137" height="613" alt="Screenshot 2025-10-03 at 6 25 25 PM" src="https://github.com/user-attachments/assets/2cdd2b20-ce47-42a6-9227-31d694e705d2" />
