### PR TITLE
feat(): add support to clone tags

### DIFF
--- a/src/main/java/io/kestra/plugin/git/AbstractCloningTask.java
+++ b/src/main/java/io/kestra/plugin/git/AbstractCloningTask.java
@@ -5,6 +5,14 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.Ref;
+import org.eclipse.jgit.revwalk.RevObject;
+import org.eclipse.jgit.revwalk.RevTag;
+import org.eclipse.jgit.revwalk.RevWalk;
+import org.eclipse.jgit.transport.RefSpec;
+import org.slf4j.Logger;
 
 @SuperBuilder(toBuilder = true)
 @NoArgsConstructor
@@ -14,4 +22,67 @@ public abstract class AbstractCloningTask extends AbstractGitTask {
         title = "Whether to clone submodules"
     )
     protected Property<Boolean> cloneSubmodules;
+
+    protected void checkoutCommit(Git git, String sha, Logger logger) throws Exception {
+        // Ensure we have a full history in case the repo was shallow by default on the remote
+        // or if the requested SHA is deep in history.
+        try {
+            // Fetch all branches and tags to guarantee the target commit is available locally.
+            git.fetch()
+                .setRefSpecs(
+                    new RefSpec("+refs/heads/*:refs/remotes/origin/*"),
+                    new RefSpec("+refs/tags/*:refs/tags/*")
+                )
+                .call();
+        } catch (Exception fetchEx) {
+            logger.warn("Fetch before checkout failed: {}", fetchEx.getMessage());
+        }
+
+        ObjectId target;
+        try {
+            target = git.getRepository().resolve(sha);
+            if (target == null) {
+                throw new IllegalArgumentException("Cannot resolve commit SHA: " + sha);
+            }
+            git.checkout().setName(target.name()).call();
+            logger.info("Checked out commit {} (detached HEAD)", target.name());
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to checkout commit " + sha + ": " + e.getMessage(), e);
+        }
+    }
+
+    protected void checkoutTag(Git git, String rTagName, Logger logger) throws Exception {
+        git.fetch()
+            .setRefSpecs(new RefSpec("+refs/tags/*:refs/tags/*"))
+            .call();
+
+        Ref tagRef = git.getRepository().findRef("refs/tags/" + rTagName);
+        if (tagRef == null) {
+            throw new IllegalArgumentException("Cannot resolve tag: " + rTagName);
+        }
+
+        ObjectId commitId;
+        try (RevWalk revWalk = new RevWalk(git.getRepository())) {
+            RevObject object = revWalk.parseAny(tagRef.getObjectId());
+
+            if (object instanceof RevTag revTag) {
+                // we have Annotated tag, need to peel to commit
+                commitId = revTag.getObject();
+            } else {
+                // we have Lightweight tag which already points to commit
+                commitId = object;
+            }
+        }
+
+        git.checkout().setName(commitId.name()).call();
+
+        logger.info("Checked out tag {} at commit {}", rTagName, commitId.name());
+    }
+
+    protected void checkoutBranch(Git git, String branch, Logger logger) throws Exception {
+        if (branch != null) {
+            git.checkout().setName(branch).call();
+            logger.info("Checked out branch {}", branch);
+        }
+    }
 }


### PR DESCRIPTION
closes #194 

```yaml
id: git_clone_tag
namespace: dev.testing

tasks:
  - id: clone_repo_at_tag
    type: io.kestra.plugin.git.Clone
    url: https://github.com/kestra-io/plugin-github
    tag: v1.0.0

```

<img width="1137" height="366" alt="Screenshot 2025-10-03 at 6 22 45 PM" src="https://github.com/user-attachments/assets/fc4c5bcb-85d9-4ae4-8651-6e6a943aa640" />
