### PR TITLE
docs(git): put simple example first / remove similar examples

### DIFF
--- a/src/main/java/io/kestra/plugin/git/PushFlows.java
+++ b/src/main/java/io/kestra/plugin/git/PushFlows.java
@@ -51,22 +51,22 @@ import static io.kestra.core.utils.Rethrow.*;
                 tasks:
                   - id: commit_and_push
                     type: io.kestra.plugin.git.PushFlows
-                    sourceNamespace: dev # the namespace from which flows are pushed
-                    targetNamespace: prod # the target production namespace; if different than sourceNamespace, the sourceNamespace in the source code will be overwritten by the targetNamespace
-                    flows: "*"  # optional list of glob patterns; by default, all flows are pushed
-                    includeChildNamespaces: true # optional boolean, false by default
+                    sourceNamespace: dev
+                    targetNamespace: prod
+                    flows: "*"
+                    includeChildNamespaces: true
                     gitDirectory: _flows
-                    url: https://github.com/kestra-io/scripts # required string
-                    username: git_username # required string needed for Auth with Git
+                    url: https://github.com/kestra-io/scripts
+                    username: git_username
                     password: "{{ secret('GITHUB_ACCESS_TOKEN') }}"
                     branch: main
-                    commitMessage: "add flows {{ now() }}" # optional string
-                    dryRun: true  # if true, you'll see what files will be added, modified or deleted based on the state in Git without overwriting the files yet
+                    commitMessage: "add flows {{ now() }}"
+                    dryRun: true
 
                 triggers:
                   - id: schedule_push
                     type: io.kestra.plugin.core.trigger.Schedule
-                    cron: "0 17 * * *" # release/push to Git every day at 5pm
+                    cron: "0 17 * * *"
                 """
         ),
         @Example(

--- a/src/main/java/io/kestra/plugin/git/PushNamespaceFiles.java
+++ b/src/main/java/io/kestra/plugin/git/PushNamespaceFiles.java
@@ -50,15 +50,14 @@ import static io.kestra.core.utils.Rethrow.throwSupplier;
                   - id: commit_and_push
                     type: io.kestra.plugin.git.PushNamespaceFiles
                     namespace: dev
-                    files: "**"  # optional list of glob patterns; by default, all files are pushed
-                    gitDirectory: _files # optional path in Git where Namespace Files should be pushed
-                    url: https://github.com/kestra-io/scripts # required string
-                    username: git_username # required string needed for Auth with Git
+                    files: "**"
+                    gitDirectory: _files
+                    url: https://github.com/kestra-io/scripts
+                    username: git_username
                     password: "{{ secret('GITHUB_ACCESS_TOKEN') }}"
-                    branch: dev # optional, uses "kestra" by default
-                    commitMessage: "add namespace files" # optional string
-                    dryRun: true  # if true, you'll see what files will be added, modified or deleted based on the state in Git without overwriting the files yet
-
+                    branch: dev
+                    commitMessage: "add namespace files"
+                    dryRun: true
                 triggers:
                   - id: schedule_push_to_git
                     type: io.kestra.plugin.core.trigger.Schedule

--- a/src/main/java/io/kestra/plugin/git/SyncFlows.java
+++ b/src/main/java/io/kestra/plugin/git/SyncFlows.java
@@ -48,15 +48,15 @@ import java.util.regex.Pattern;
                 tasks:
                   - id: git
                     type: io.kestra.plugin.git.SyncFlows
-                    gitDirectory: flows # optional; set to _flows by default
-                    targetNamespace: git # required
-                    includeChildNamespaces: true # optional; by default, it's set to false to allow explicit definition
-                    delete: true # optional; by default, it's set to false to avoid destructive behavior
-                    url: https://github.com/kestra-io/flows # required
+                    gitDirectory: flows
+                    targetNamespace: git
+                    includeChildNamespaces: true
+                    delete: true
+                    url: https://github.com/kestra-io/flows
                     branch: main
                     username: git_username
                     password: "{{ secret('GITHUB_ACCESS_TOKEN') }}"
-                    dryRun: true  # if true, the task will only log which flows from Git will be added/modified or deleted in kestra without making any changes in kestra backend yet
+                    dryRun: true
 
                 triggers:
                   - id: every_full_hour

--- a/src/main/java/io/kestra/plugin/git/SyncNamespaceFiles.java
+++ b/src/main/java/io/kestra/plugin/git/SyncNamespaceFiles.java
@@ -49,13 +49,13 @@ import java.util.Optional;
                   - id: git
                     type: io.kestra.plugin.git.SyncNamespaceFiles
                     namespace: prod
-                    gitDirectory: _files # optional; set to _files by default
-                    delete: true # optional; by default, it's set to false to avoid destructive behavior
+                    gitDirectory: _files
+                    delete: true
                     url: https://github.com/kestra-io/flows
                     branch: main
                     username: git_username
                     password: "{{ secret('GITHUB_ACCESS_TOKEN') }}"
-                    dryRun: true  # if true, the task will only log which flows from Git will be added/modified or deleted in kestra without making any changes in kestra backend yet
+                    dryRun: true
 
                 triggers:
                   - id: every_minute


### PR DESCRIPTION
Clean up. I removed comments from some of the examples too. They repeat what the plugin docs property section does (2 places to maintain), it's not something we do consistently, and it makes copying and pasting examples annoying if you don't want all the comments in your flow.