### PR TITLE
fix: sync to be compatible with kestra version for flow validation

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 version=1.2.1-SNAPSHOT
-kestraVersion=1.2.0
+kestraVersion=1.2.1

--- a/src/main/java/io/kestra/plugin/git/NamespaceSync.java
+++ b/src/main/java/io/kestra/plugin/git/NamespaceSync.java
@@ -5,6 +5,7 @@ import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.exceptions.KestraRuntimeException;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.flows.FlowSource;
 import io.kestra.core.models.flows.FlowWithSource;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
@@ -301,7 +302,7 @@ public class NamespaceSync extends AbstractCloningTask implements RunnableTask<N
                     diff.add(DiffLine.added(fileRel, key, Kind.FLOW));
                     if (!rDryRun) apply.add(() -> {
                         try {
-                            var flowValidated = fs.validate(rc.flowInfo().tenantId(), gitNode.rawYaml).getFirst();
+                            var flowValidated = fs.validate(rc.flowInfo().tenantId(), List.of(new FlowSource(key, gitNode.rawYaml))).getFirst();
 
                             if (flowValidated.getConstraints() != null) {
                                 throw new FlowProcessingException(flowValidated.getConstraints());
@@ -360,7 +361,7 @@ public class NamespaceSync extends AbstractCloningTask implements RunnableTask<N
                     diff.add(DiffLine.updatedKestra(fileRel, key, Kind.FLOW));
                     if (!rDryRun) apply.add(() -> {
                         try {
-                            var flowValidated = fs.validate(rc.flowInfo().tenantId(), gitNode.rawYaml).getFirst();
+                            var flowValidated = fs.validate(rc.flowInfo().tenantId(), List.of(new FlowSource(key, gitNode.rawYaml))).getFirst();
 
                             if (flowValidated.getConstraints() != null) {
                                 throw new FlowProcessingException(flowValidated.getConstraints());

--- a/src/main/java/io/kestra/plugin/git/SyncFlows.java
+++ b/src/main/java/io/kestra/plugin/git/SyncFlows.java
@@ -5,19 +5,18 @@ import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.flows.FlowSource;
 import io.kestra.core.models.flows.FlowWithException;
 import io.kestra.core.models.flows.FlowWithSource;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.DefaultRunContext;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.services.FlowService;
-import io.kestra.sdk.KestraClient;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.apache.commons.io.IOUtils;
-import org.eclipse.jgit.api.Git;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -204,7 +203,7 @@ public class SyncFlows extends AbstractSyncTask<Flow, SyncFlows.Output> {
 
         String flowSource = SyncFlows.replaceNamespace(renderedNamespace, uri, inputStream);
 
-        var flowValidated = flowService.validate(runContext.flowInfo().tenantId(), flowSource).getFirst();
+        var flowValidated = flowService.validate(runContext.flowInfo().tenantId(), List.of(new FlowSource(null, flowSource))).getFirst();
 
         if (flowValidated.getConstraints() != null) {
             var ref = uri.getPath();
@@ -245,7 +244,7 @@ public class SyncFlows extends AbstractSyncTask<Flow, SyncFlows.Output> {
 
         String flowSource = SyncFlows.replaceNamespace(renderedNamespace, uri, inputStream);
 
-        var flowValidated = flowService.validate(runContext.flowInfo().tenantId(), flowSource).getFirst();
+        var flowValidated = flowService.validate(runContext.flowInfo().tenantId(), List.of(new FlowSource(null, flowSource))).getFirst();
 
         if (flowValidated.getConstraints() != null) {
             var ref = uri.getPath();


### PR DESCRIPTION
- closes https://github.com/kestra-io/kestra/issues/14294
- Companion PR: https://github.com/kestra-io/plugin-ee-git/pull/70

For context, validate() signature changed in core 1.2, so make plugin adapt to it.
We will remove this in 1.3.0, since we have a strict parsing for import flow, so we dont need to validate first