### PR TITLE
fix(sync-namespace-files): avoid rewriting unchanged namespace files

### DIFF
--- a/src/main/java/io/kestra/plugin/git/SyncNamespaceFiles.java
+++ b/src/main/java/io/kestra/plugin/git/SyncNamespaceFiles.java
@@ -6,8 +6,6 @@ import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.storages.Namespace;
 import io.kestra.core.storages.NamespaceFile;
-import io.kestra.core.storages.StorageContext;
-import io.kestra.core.utils.WindowsUtils;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
@@ -16,8 +14,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 @SuperBuilder(toBuilder = true)
@@ -109,7 +110,7 @@ public class SyncNamespaceFiles extends AbstractSyncTask<NamespaceFile, SyncName
         description = "Namespace receiving the files; defaults to the current flow namespace."
     )
     @Builder.Default
-    private Property<String> namespace = new Property<>("{{ flow.namespace }}");
+    private Property<String> namespace = Property.ofExpression("{{ flow.namespace }}");
 
     @Schema(
         title = "Git directory for Namespace Files",
@@ -137,24 +138,109 @@ public class SyncNamespaceFiles extends AbstractSyncTask<NamespaceFile, SyncName
 
     @Override
     protected NamespaceFile
-    simulateResourceWrite(RunContext runContext, String renderedNamespace, URI uri, InputStream inputStream) {
+    simulateResourceWrite(RunContext runContext, String renderedNamespace, URI uri, InputStream inputStream) throws IOException {
+        var namespace = runContext.storage().namespace(renderedNamespace);
+        var path = Path.of(uri.getPath());
+        var existingResource = this.findExistingResource(namespace, renderedNamespace, uri);
+
+        if (inputStream == null) {
+            return existingResource.orElseGet(() -> NamespaceFile.of(renderedNamespace, uri));
+        }
+
+        if (existingResource.isPresent() && !existingResource.get().isDirectory()) {
+            if (this.hasSameContent(namespace, path, inputStream)) {
+                return existingResource.get();
+            }
+
+            return NamespaceFile.of(renderedNamespace, uri, existingResource.get().version() + 1);
+        }
+
         return NamespaceFile.of(renderedNamespace, uri);
     }
 
     @Override
-    protected NamespaceFile writeResource(RunContext runContext, String renderedNamespace, URI uri, InputStream inputStream) throws IOException, URISyntaxException {
-        Namespace namespace = runContext.storage().namespace(renderedNamespace);
-        NamespaceFile.of(renderedNamespace, uri);
+    protected NamespaceFile writeResource(RunContext runContext, String renderedNamespace, URI uri, InputStream inputStream) throws IOException {
+        var namespace = runContext.storage().namespace(renderedNamespace);
+        var path = Path.of(uri.getPath());
+        var existingResource = this.findExistingResource(namespace, renderedNamespace, uri);
+
         try {
-            return inputStream == null ?
-                namespace.createDirectory(Path.of(uri.getPath())) :
-                namespace.putFile(Path.of(uri.getPath()), inputStream).stream()
-                    .filter(nf -> !nf.isDirectory())
-                    .findFirst()
-                    .orElseThrow();
+            if (inputStream == null) {
+                if (existingResource.isPresent()) {
+                    return existingResource.get();
+                }
+                return namespace.createDirectory(path);
+            }
+
+            if (existingResource.isPresent() && !existingResource.get().isDirectory()) {
+                var tempGitFile = runContext.workingDir().createTempFile(".namespace-file-sync").toFile().toPath();
+                try {
+                    Files.copy(inputStream, tempGitFile, StandardCopyOption.REPLACE_EXISTING);
+                    if (this.hasSameContent(namespace, path, tempGitFile)) {
+                        return existingResource.get();
+                    }
+
+                    try (var gitContent = Files.newInputStream(tempGitFile)) {
+                        return this.putFile(namespace, path, gitContent);
+                    }
+                } finally {
+                    Files.deleteIfExists(tempGitFile);
+                }
+            }
+
+            return this.putFile(namespace, path, inputStream);
         } catch (URISyntaxException e) {
             throw new IOException(e);
         }
+    }
+
+    private NamespaceFile putFile(Namespace namespace, Path path, InputStream inputStream) throws IOException, URISyntaxException {
+        return namespace.putFile(path, inputStream).stream()
+            .filter(nf -> !nf.isDirectory())
+            .findFirst()
+            .orElseThrow();
+    }
+
+    private boolean hasSameContent(Namespace namespace, Path path, Path sourceFile) throws IOException {
+        try (var sourceFileContent = Files.newInputStream(sourceFile)) {
+            return this.hasSameContent(namespace, path, sourceFileContent);
+        }
+    }
+
+    private boolean hasSameContent(Namespace namespace, Path path, InputStream sourceContent) throws IOException {
+        try (var existingContent = namespace.getFileContent(path)) {
+            return this.streamsEqual(sourceContent, existingContent);
+        }
+    }
+
+    private boolean streamsEqual(InputStream first, InputStream second) throws IOException {
+        var firstBuffer = new byte[8192];
+        var secondBuffer = new byte[8192];
+
+        while (true) {
+            var firstRead = first.read(firstBuffer);
+            var secondRead = second.read(secondBuffer);
+            if (firstRead != secondRead) {
+                return false;
+            }
+            if (firstRead == -1) {
+                return true;
+            }
+
+            for (var i = 0; i < firstRead; i++) {
+                if (firstBuffer[i] != secondBuffer[i]) {
+                    return false;
+                }
+            }
+        }
+    }
+
+    private Optional<NamespaceFile> findExistingResource(Namespace namespace, String renderedNamespace, URI uri) throws IOException {
+        var targetUri = this.toUri(renderedNamespace, NamespaceFile.of(renderedNamespace, uri));
+        return namespace.all()
+            .stream()
+            .filter(resource -> Objects.equals(this.toUri(renderedNamespace, resource), targetUri))
+            .findFirst();
     }
 
     @Override
@@ -164,8 +250,9 @@ public class SyncNamespaceFiles extends AbstractSyncTask<NamespaceFile, SyncName
             syncState = SyncState.DELETED;
         } else if (resourceBeforeUpdate == null) {
             syncState = SyncState.ADDED;
+        } else if (Objects.equals(resourceBeforeUpdate.uri(), resourceAfterUpdate.uri())) {
+            syncState = SyncState.UNCHANGED;
         } else {
-            // here we don't want to query the content of the file to check if it has changed
             syncState = SyncState.OVERWRITTEN;
         }
 

--- a/src/test/java/io/kestra/plugin/git/SyncNamespaceFilesTest.java
+++ b/src/test/java/io/kestra/plugin/git/SyncNamespaceFilesTest.java
@@ -28,7 +28,10 @@ import java.util.stream.Collectors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 
 @KestraTest
 public class SyncNamespaceFilesTest extends AbstractGitTest {
@@ -209,6 +212,34 @@ public class SyncNamespaceFilesTest extends AbstractGitTest {
         assertDiffs(runContext, syncOutput.diffFileUri(), defaultCaseDiffs(true));
     }
 
+    @Test
+    void secondSyncWithoutGitChanges_ShouldReportUnchangedFiles() throws Exception {
+        var task = SyncNamespaceFiles.builder()
+            .url(new Property<>("{{url}}"))
+            .username(new Property<>("{{pat}}"))
+            .password(new Property<>("{{pat}}"))
+            .branch(new Property<>("{{branch}}"))
+            .gitDirectory(new Property<>("{{gitDirectory}}"))
+            .namespace(new Property<>("{{namespace}}"))
+            .build();
+
+        task.run(runContext());
+        var secondRunContext = runContext();
+        var secondSyncOutput = task.run(secondRunContext);
+
+        var secondDiffs = readDiffs(secondRunContext, secondSyncOutput.diffFileUri());
+        assertThat(secondDiffs, hasSize(defaultCaseDiffs(false).size()));
+        assertThat(secondDiffs.stream().map(diff -> diff.get("syncState")).toList(), not(hasItem("OVERWRITTEN")));
+        assertThat(
+            secondDiffs.stream()
+                .filter(diff -> "to_clone/cloned.json".equals(diff.get("gitPath")))
+                .findFirst()
+                .orElseThrow()
+                .get("syncState"),
+            is("UNCHANGED")
+        );
+    }
+
     private static List<Map<String, String>> defaultCaseDiffs(boolean withDeleted) {
         ArrayList<Map<String, String>> diffs = new ArrayList<>(List.of(
                 Map.of("gitPath", "to_clone/_flows/", "syncState", "ADDED", "kestraPath", "/my/namespace/_files/_flows/"),
@@ -257,15 +288,19 @@ public class SyncNamespaceFilesTest extends AbstractGitTest {
     }
 
     private static void assertDiffs(RunContext runContext, URI diffFileUri, List<Map<String, String>> expectedDiffs) throws IOException {
-        String diffSummary = IOUtils.toString(runContext.storage().getFile(diffFileUri), StandardCharsets.UTF_8);
-        List<Map<String, String>> diffMaps = diffSummary.lines()
-                .map(Rethrow.throwFunction(diff -> JacksonMapper.ofIon().readValue(
-                        diff,
-                        new TypeReference<Map<String, String>>() {
-                        }
-                )))
-                .toList();
+        List<Map<String, String>> diffMaps = readDiffs(runContext, diffFileUri);
         assertThat(diffMaps, containsInAnyOrder(expectedDiffs.toArray(Map[]::new)));
+    }
+
+    private static List<Map<String, String>> readDiffs(RunContext runContext, URI diffFileUri) throws IOException {
+        String diffSummary = IOUtils.toString(runContext.storage().getFile(diffFileUri), StandardCharsets.UTF_8);
+        return diffSummary.lines()
+            .map(Rethrow.throwFunction(diff -> JacksonMapper.ofIon().readValue(
+                diff,
+                new TypeReference<Map<String, String>>() {
+                }
+            )))
+            .toList();
     }
 
     private void assertNamespaceFileContent(RunContext runContext, String namespaceFileUri, String expectedFileContent) throws IOException {


### PR DESCRIPTION
fixes https://github.com/kestra-io/plugin-git/issues/248

<!-- Thanks for submitting a Pull Request to kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "close" to automatically close an issue. For example, `close #1234` will close issue #1234. -->

### What changes are being made and why?
<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->

---

### How the changes have been QAed?

<!-- Include example code that shows how this PR has been QAed. The code should present a complete yet easily reproducible flow.

```yaml
# Your example flow code here
```

Note that this is not a replacement for unit tests but rather a way to demonstrate how the changes work in a real-life scenario, as the end-user would experience them.

Remove this section if this change applies to all flows or to the documentation only. -->

---

### Setup Instructions

<!--If there are any setup requirements like API keys or trial accounts, kindly include brief bullet-points-description outlining the setup process below.

- [External System Documentation](URL)
- Steps to set up the necessary resources

If there are no setup requirements, you can remove this section.

Thank you for your contribution. ❤️  -->

---

### Contributor Checklist ✅

- [x] I have read and followed the [plugin contribution guidelines](https://kestra.io/docs/plugin-developer-guide/contribution-guidelines)
