### PR TITLE
feat: replace DefaultRunContext with Kestra SDK in Sync* and Push* tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ repositories {
     }
 }
 
-final targetJavaVersion = JavaVersion.VERSION_21
+final targetJavaVersion = JavaVersion.VERSION_25
 
 java {
     sourceCompatibility = targetJavaVersion
@@ -100,6 +100,7 @@ dependencies {
     testImplementation group: "io.kestra", name: "repository-memory", version: kestraVersion
     testImplementation group: "io.kestra", name: "runner-memory", version: kestraVersion
     testImplementation group: "io.kestra", name: "storage-local", version: kestraVersion
+    testImplementation group: "io.kestra", name: "indexer", version: kestraVersion
 
     // test
     testImplementation "org.junit.jupiter:junit-jupiter-engine"

--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,9 @@ dependencies {
     api 'org.eclipse.jgit:org.eclipse.jgit:7.6.0.202603022253-r'
     api 'org.eclipse.jgit:org.eclipse.jgit.ssh.jsch:7.6.0.202603022253-r'
     api "org.eclipse.jgit:org.eclipse.jgit.http.apache:7.6.0.202603022253-r"
+
+    // kestra API client
+    implementation "io.kestra:kestra-api-client:1.0.11"
 }
 
 
@@ -107,8 +110,6 @@ dependencies {
     testImplementation "org.hamcrest:hamcrest"
     testImplementation "org.hamcrest:hamcrest-library"
 
-    // kestra API client
-    implementation "io.kestra:kestra-api-client:1.0.11"
 }
 
 /**********************************************************************************************************************\

--- a/build.gradle
+++ b/build.gradle
@@ -108,7 +108,7 @@ dependencies {
     testImplementation "org.hamcrest:hamcrest-library"
 
     // kestra API client
-    implementation "io.kestra:kestra-api-client:1.0.5"
+    implementation "io.kestra:kestra-api-client:1.0.11"
 }
 
 /**********************************************************************************************************************\

--- a/build.gradle
+++ b/build.gradle
@@ -110,6 +110,9 @@ dependencies {
     testImplementation "org.hamcrest:hamcrest"
     testImplementation "org.hamcrest:hamcrest-library"
 
+    // Testcontainers — used for container-based integration tests (e.g. SyncFlowsContainerTest)
+    testImplementation "org.testcontainers:testcontainers:2.0.3"
+    testImplementation "org.testcontainers:junit-jupiter:1.21.4"
 }
 
 /**********************************************************************************************************************\

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ repositories {
     }
 }
 
-final targetJavaVersion = JavaVersion.VERSION_25
+final targetJavaVersion = JavaVersion.VERSION_21
 
 java {
     sourceCompatibility = targetJavaVersion

--- a/build.gradle
+++ b/build.gradle
@@ -100,7 +100,6 @@ dependencies {
     testImplementation group: "io.kestra", name: "repository-memory", version: kestraVersion
     testImplementation group: "io.kestra", name: "runner-memory", version: kestraVersion
     testImplementation group: "io.kestra", name: "storage-local", version: kestraVersion
-    testImplementation group: "io.kestra", name: "indexer", version: kestraVersion
 
     // test
     testImplementation "org.junit.jupiter:junit-jupiter-engine"

--- a/src/main/java/io/kestra/plugin/git/AbstractCloningTask.java
+++ b/src/main/java/io/kestra/plugin/git/AbstractCloningTask.java
@@ -21,8 +21,7 @@ import io.kestra.core.runners.SDK;
 import io.kestra.sdk.KestraClient;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import lombok.experimental.SuperBuilder;
 import io.kestra.core.models.annotations.PluginProperty;
 
@@ -50,6 +49,10 @@ public abstract class AbstractCloningTask extends AbstractGitTask {
     @PluginProperty(group = "advanced")
     protected Property<Boolean> cloneSubmodules;
 
+    @Schema(title = "Kestra API authentication")
+    @PluginProperty(group = "connection")
+    protected Auth auth;
+
     protected KestraClient kestraClient(RunContext runContext) throws IllegalVariableEvaluationException {
         String rKestraUrl = runContext.render(kestraUrl).as(String.class)
             .orElseGet(() -> {
@@ -69,11 +72,53 @@ public abstract class AbstractCloningTask extends AbstractGitTask {
 
         var normalizedUrl = rKestraUrl.trim().replaceAll("/+$", "");
         var builder = KestraClient.builder().url(normalizedUrl);
-        Optional<SDK.Auth> autoAuth = runContext.sdk().defaultAuthentication();
-        if (autoAuth.isPresent() && autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
-            return builder.basicAuth(autoAuth.get().username().get(), autoAuth.get().password().get()).build();
+
+        if (auth != null) {
+            Optional<String> maybeUsername = runContext.render(auth.username).as(String.class);
+            Optional<String> maybePassword = runContext.render(auth.password).as(String.class);
+            if (maybeUsername.isPresent() && maybePassword.isPresent()) {
+                return builder.basicAuth(maybeUsername.get(), maybePassword.get()).build();
+            }
+            if (maybeUsername.isPresent() || maybePassword.isPresent()) {
+                throw new IllegalArgumentException("Both username and password are required for HTTP Basic authentication");
+            }
+            if (runContext.render(auth.auto).as(Boolean.class).orElse(Boolean.TRUE)) {
+                Optional<SDK.Auth> autoAuth = runContext.sdk().defaultAuthentication();
+                if (autoAuth.isPresent() && autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
+                    return builder.basicAuth(autoAuth.get().username().get(), autoAuth.get().password().get()).build();
+                }
+            }
+        } else {
+            Optional<SDK.Auth> autoAuth = runContext.sdk().defaultAuthentication();
+            if (autoAuth.isPresent() && autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
+                return builder.basicAuth(autoAuth.get().username().get(), autoAuth.get().password().get()).build();
+            }
         }
+
         return builder.build();
+    }
+
+    @Builder
+    @Getter
+    public static class Auth {
+        @Schema(title = "Username for HTTP Basic authentication.")
+        @PluginProperty(secret = true, group = "connection")
+        private Property<String> username;
+
+        @Schema(title = "Password for HTTP Basic authentication.")
+        @PluginProperty(secret = true, group = "connection")
+        private Property<String> password;
+
+        @Schema(
+            title = "Automatically retrieve credentials from Kestra's configuration if available",
+            description = """
+                Can be configured globally in the Kestra configuration file:
+                - Set `kestra.tasks.sdk.authentication.api-token` for API token auth
+                - Set `kestra.tasks.sdk.authentication.username` and `kestra.tasks.sdk.authentication.password` for HTTP Basic auth"""
+        )
+        @Builder.Default
+        @PluginProperty(group = "advanced")
+        private Property<Boolean> auto = Property.ofValue(Boolean.TRUE);
     }
 
     protected void checkoutCommit(Git git, String sha, Logger logger, boolean noTags) throws Exception {

--- a/src/main/java/io/kestra/plugin/git/AbstractCloningTask.java
+++ b/src/main/java/io/kestra/plugin/git/AbstractCloningTask.java
@@ -23,6 +23,7 @@ import io.kestra.sdk.KestraClient;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import lombok.extern.jackson.Jacksonized;
 import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder(toBuilder = true)
@@ -84,14 +85,24 @@ public abstract class AbstractCloningTask extends AbstractGitTask {
             }
             if (runContext.render(auth.auto).as(Boolean.class).orElse(Boolean.TRUE)) {
                 Optional<SDK.Auth> autoAuth = runContext.sdk().defaultAuthentication();
-                if (autoAuth.isPresent() && autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
-                    return builder.basicAuth(autoAuth.get().username().get(), autoAuth.get().password().get()).build();
+                if (autoAuth.isPresent()) {
+                    if (autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
+                        return builder.basicAuth(autoAuth.get().username().get(), autoAuth.get().password().get()).build();
+                    }
+                    if (autoAuth.get().apiToken().isPresent()) {
+                        return builder.tokenAuth(autoAuth.get().apiToken().get()).build();
+                    }
                 }
             }
         } else {
             Optional<SDK.Auth> autoAuth = runContext.sdk().defaultAuthentication();
-            if (autoAuth.isPresent() && autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
-                return builder.basicAuth(autoAuth.get().username().get(), autoAuth.get().password().get()).build();
+            if (autoAuth.isPresent()) {
+                if (autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
+                    return builder.basicAuth(autoAuth.get().username().get(), autoAuth.get().password().get()).build();
+                }
+                if (autoAuth.get().apiToken().isPresent()) {
+                    return builder.tokenAuth(autoAuth.get().apiToken().get()).build();
+                }
             }
         }
 
@@ -100,6 +111,7 @@ public abstract class AbstractCloningTask extends AbstractGitTask {
 
     @Builder
     @Getter
+    @Jacksonized
     public static class Auth {
         @Schema(title = "Username for HTTP Basic authentication.")
         @PluginProperty(secret = true, group = "connection")

--- a/src/main/java/io/kestra/plugin/git/AbstractCloningTask.java
+++ b/src/main/java/io/kestra/plugin/git/AbstractCloningTask.java
@@ -2,6 +2,7 @@ package io.kestra.plugin.git;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.lib.ObjectId;
@@ -13,7 +14,11 @@ import org.eclipse.jgit.transport.RefSpec;
 import org.eclipse.jgit.transport.TagOpt;
 import org.slf4j.Logger;
 
+import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.SDK;
+import io.kestra.sdk.KestraClient;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
@@ -25,12 +30,51 @@ import io.kestra.core.models.annotations.PluginProperty;
 @NoArgsConstructor
 @Getter
 public abstract class AbstractCloningTask extends AbstractGitTask {
+    private static final String DEFAULT_KESTRA_URL = "http://localhost:8080";
+    private static final String KESTRA_URL_TEMPLATE = "{{ kestra.url }}";
+
+    @Schema(
+        title = "Kestra API URL",
+        description = """
+            URL of the Kestra server API.
+            If not set, the value of `kestra.url` from the Kestra configuration is used.
+            If that is also not set, defaults to `http://localhost:8080`."""
+    )
+    @PluginProperty(group = "connection")
+    protected Property<String> kestraUrl;
+
     @Schema(
         title = "Clone submodules",
         description = "Default false; enable to fetch and initialize nested submodules."
     )
     @PluginProperty(group = "advanced")
     protected Property<Boolean> cloneSubmodules;
+
+    protected KestraClient kestraClient(RunContext runContext) throws IllegalVariableEvaluationException {
+        String rKestraUrl = runContext.render(kestraUrl).as(String.class)
+            .orElseGet(() -> {
+                try {
+                    String rendered = runContext.render(KESTRA_URL_TEMPLATE);
+                    return (rendered == null || rendered.isBlank()) ? DEFAULT_KESTRA_URL : rendered;
+                } catch (IllegalVariableEvaluationException e) {
+                    return DEFAULT_KESTRA_URL;
+                }
+            });
+
+        if (rKestraUrl == null || rKestraUrl.isBlank()) {
+            rKestraUrl = DEFAULT_KESTRA_URL;
+        }
+
+        runContext.logger().debug("Kestra URL: {}", rKestraUrl);
+
+        var normalizedUrl = rKestraUrl.trim().replaceAll("/+$", "");
+        var builder = KestraClient.builder().url(normalizedUrl);
+        Optional<SDK.Auth> autoAuth = runContext.sdk().defaultAuthentication();
+        if (autoAuth.isPresent() && autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
+            return builder.basicAuth(autoAuth.get().username().get(), autoAuth.get().password().get()).build();
+        }
+        return builder.build();
+    }
 
     protected void checkoutCommit(Git git, String sha, Logger logger, boolean noTags) throws Exception {
         // Ensure we have a full history in case the repo was shallow by default on the remote

--- a/src/main/java/io/kestra/plugin/git/AbstractKestraTask.java
+++ b/src/main/java/io/kestra/plugin/git/AbstractKestraTask.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import lombok.extern.jackson.Jacksonized;
 import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
@@ -70,6 +71,9 @@ public abstract class AbstractKestraTask extends AbstractGitTask {
                     if (autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
                         return builder.basicAuth(autoAuth.get().username().get(), autoAuth.get().password().get()).build();
                     }
+                    if (autoAuth.get().apiToken().isPresent()) {
+                        return builder.tokenAuth(autoAuth.get().apiToken().get()).build();
+                    }
                 }
             }
             throw new IllegalArgumentException("No authentication method provided");
@@ -80,6 +84,9 @@ public abstract class AbstractKestraTask extends AbstractGitTask {
                 if (autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
                     return builder.basicAuth(autoAuth.get().username().get(), autoAuth.get().password().get()).build();
                 }
+                if (autoAuth.get().apiToken().isPresent()) {
+                    return builder.tokenAuth(autoAuth.get().apiToken().get()).build();
+                }
             }
         }
         return builder.build();
@@ -87,6 +94,7 @@ public abstract class AbstractKestraTask extends AbstractGitTask {
 
     @Builder
     @Getter
+    @Jacksonized
     public static class Auth {
         @Schema(title = "Username for HTTP Basic authentication.")
         @PluginProperty(secret = true, group = "connection")

--- a/src/main/java/io/kestra/plugin/git/NamespaceSync.java
+++ b/src/main/java/io/kestra/plugin/git/NamespaceSync.java
@@ -16,6 +16,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
 
 import org.eclipse.jgit.api.AddCommand;
 import org.eclipse.jgit.api.CommitCommand;
@@ -31,16 +33,20 @@ import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.exceptions.KestraRuntimeException;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
-import io.kestra.core.models.flows.FlowSource;
+import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.exceptions.KestraRuntimeException;
 import io.kestra.core.models.flows.FlowWithSource;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
-import io.kestra.core.repositories.FlowRepositoryInterface;
-import io.kestra.core.runners.DefaultRunContext;
 import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.SDK;
 import io.kestra.core.serializers.YamlParser;
-import io.kestra.core.services.FlowService;
 import io.kestra.core.storages.NamespaceFile;
+import io.kestra.sdk.KestraClient;
+import io.kestra.sdk.internal.ApiException;
+import io.kestra.sdk.model.QueryFilter;
+import io.kestra.sdk.model.QueryFilterField;
+import io.kestra.sdk.model.QueryFilterOp;
 import io.kestra.plugin.git.services.GitService;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -215,10 +221,6 @@ public class NamespaceSync extends AbstractCloningTask implements RunnableTask<N
     private static final String FLOWS_DIR = "flows";
     private static final String FILES_DIR = "files";
 
-    private FlowService flowService(RunContext rc) {
-        return ((DefaultRunContext) rc).services().additionalService(FlowService.class);
-    }
-
     @Override
     public Output run(RunContext runContext) throws Exception {
         var gitService = new GitService(this);
@@ -228,11 +230,15 @@ public class NamespaceSync extends AbstractCloningTask implements RunnableTask<N
 
         runContext.logger().info("Now in NamespaceSync for namespace {}", rNamespace);
 
-        var flowRepository = ((DefaultRunContext) runContext).services().additionalService(FlowRepositoryInterface.class);
         var tenantId = runContext.flowInfo().tenantId();
-        var distinctNamespaces = flowRepository.findDistinctNamespace(tenantId);
-        if (!distinctNamespaces.contains(rNamespace)) {
-            throw new IllegalArgumentException("The namespace does not exist in the '" + tenantId + "' tenant.");
+        var kestraClient = kestraClient(runContext);
+        try {
+            kestraClient.namespaces().namespace(rNamespace, tenantId);
+        } catch (ApiException e) {
+            if (e.getCode() == 404) {
+                throw new IllegalArgumentException("The namespace does not exist in the '" + tenantId + "' tenant.");
+            }
+            throw e;
         }
 
         var rGitDirectory = runContext.render(this.gitDirectory).as(String.class).orElse(null);
@@ -331,7 +337,6 @@ public class NamespaceSync extends AbstractCloningTask implements RunnableTask<N
         SourceOfTruth rSource, WhenMissingInSource rMissing, OnInvalidSyntax rInvalid,
         List<String> protectedNamespace, boolean rDryRun,
         List<DiffLine> diff, List<Runnable> apply) {
-        FlowService fs = flowService(rc);
         Map<String, GitNode> gitByKey = gitTree.nodes;
         Map<String, FlowWithSource> kesByKey = kes.flows;
         String tenant = rc.flowInfo().tenantId();
@@ -350,12 +355,14 @@ public class NamespaceSync extends AbstractCloningTask implements RunnableTask<N
                         apply.add(() ->
                         {
                             try {
-                                var flowValidated = fs.validate(rc.flowInfo().tenantId(), List.of(new FlowSource(key, gitNode.rawYaml))).getFirst();
+                                var kestraClient = kestraClient(rc);
+                                var flowValidated = kestraClient.flows().validateFlows(tenant, gitNode.rawYaml).getFirst();
 
                                 if (flowValidated.getConstraints() != null) {
                                     throw new FlowProcessingException(flowValidated.getConstraints());
                                 }
-                                fs.importFlow(tenant, gitNode.rawYaml, false);
+                                var flowId = YamlParser.parse(gitNode.rawYaml, io.kestra.core.models.flows.Flow.class).getId();
+                                kestraClient.flows().importFlows(false, tenant, toNamedTempFile(flowId + ".yaml", gitNode.rawYaml));
                             } catch (Exception e) {
                                 handleInvalid(rc, rInvalid, "FLOW " + key, e);
                             }
@@ -397,7 +404,15 @@ public class NamespaceSync extends AbstractCloningTask implements RunnableTask<N
                             }
                             diff.add(DiffLine.deletedKestra(fileRelFromKey(FLOWS_DIR, key), key, Kind.FLOW));
                             if (!rDryRun)
-                                apply.add(() -> deleteFlow(rc, kestraFlowWithSource));
+                                apply.add(() ->
+                                {
+                                    try {
+                                        kestraClient(rc).flows().deleteFlow(
+                                            kestraFlowWithSource.getNamespace(), kestraFlowWithSource.getId(), tenant);
+                                    } catch (ApiException | IllegalVariableEvaluationException e) {
+                                        handleInvalid(rc, rInvalid, "FLOW " + key, e);
+                                    }
+                                });
                         }
                         case FAIL ->
                             throw new KestraRuntimeException("Sync failed: FLOW missing in Git but present in KESTRA for key " + key);
@@ -415,13 +430,14 @@ public class NamespaceSync extends AbstractCloningTask implements RunnableTask<N
                         apply.add(() ->
                         {
                             try {
-                                var flowValidated = fs.validate(rc.flowInfo().tenantId(), List.of(new FlowSource(key, gitNode.rawYaml))).getFirst();
+                                var kestraClient = kestraClient(rc);
+                                var flowValidated = kestraClient.flows().validateFlows(tenant, gitNode.rawYaml).getFirst();
 
                                 if (flowValidated.getConstraints() != null) {
                                     throw new FlowProcessingException(flowValidated.getConstraints());
                                 }
-
-                                fs.importFlow(tenant, gitNode.rawYaml, false);
+                                var flowId = YamlParser.parse(gitNode.rawYaml, io.kestra.core.models.flows.Flow.class).getId();
+                                kestraClient.flows().importFlows(false, tenant, toNamedTempFile(flowId + ".yaml", gitNode.rawYaml));
                             } catch (Exception e) {
                                 handleInvalid(rc, rInvalid, "FLOW " + key, e);
                             }
@@ -526,12 +542,11 @@ public class NamespaceSync extends AbstractCloningTask implements RunnableTask<N
     }
 
     private KestraState loadKestraState(RunContext rc, String rootNamespace, OnInvalidSyntax rOnInvalidSyntax) {
-        FlowService fs = flowService(rc);
         String tenant = rc.flowInfo().tenantId();
 
         List<FlowWithSource> allFlows;
         try {
-            allFlows = fs.findByNamespaceWithSource(tenant, rootNamespace);
+            allFlows = fetchFlowsFromKestra(rc, tenant, rootNamespace);
         } catch (Exception e) {
             handleInvalid(rc, rOnInvalidSyntax, "flows for namespace " + rootNamespace, e);
             allFlows = List.of();
@@ -541,6 +556,67 @@ public class NamespaceSync extends AbstractCloningTask implements RunnableTask<N
             .collect(Collectors.toMap(f -> key(f.getNamespace(), f.getId()), Function.identity(), (a, b) -> a));
 
         return new KestraState(flowsWithSource);
+    }
+
+    private List<FlowWithSource> fetchFlowsFromKestra(RunContext rc, String tenantId, String namespace) {
+        try {
+            byte[] zippedFlows = kestraClient(rc).flows().exportFlowsByQuery(
+                tenantId,
+                List.of(new QueryFilter().field(QueryFilterField.NAMESPACE).operation(QueryFilterOp.EQUALS).value(namespace))
+            );
+            List<FlowWithSource> flows = new ArrayList<>();
+            try (
+                var bais = new ByteArrayInputStream(zippedFlows);
+                var zis = new ZipInputStream(bais)
+            ) {
+                ZipEntry entry;
+                while ((entry = zis.getNextEntry()) != null) {
+                    if (!entry.getName().endsWith(".yml") && !entry.getName().endsWith(".yaml")) {
+                        continue;
+                    }
+                    var yaml = new String(zis.readAllBytes(), StandardCharsets.UTF_8);
+                    try {
+                        flows.add(FlowWithSource.of(YamlParser.parse(yaml, io.kestra.core.models.flows.Flow.class), yaml));
+                    } catch (Exception e) {
+                        rc.logger().warn("Skipping invalid flow from entry {}: {}", entry.getName(), e.getMessage());
+                    }
+                }
+            }
+            return flows;
+        } catch (IOException | ApiException | IllegalVariableEvaluationException e) {
+            throw new KestraRuntimeException("Failed to export flows from Kestra for namespace " + namespace, e);
+        }
+    }
+
+    private File toNamedTempFile(String fileName, String yaml) {
+        try {
+            Path tmpPath = Files.createTempDirectory("kestra-import")
+                .resolve(fileName.endsWith(".yaml") ? fileName : fileName + ".yaml");
+            Files.createDirectories(tmpPath.getParent());
+            Files.writeString(tmpPath, yaml, StandardCharsets.UTF_8);
+            return tmpPath.toFile();
+        } catch (IOException e) {
+            throw new KestraRuntimeException("Failed to create named file for: " + fileName, e);
+        }
+    }
+
+    private KestraClient kestraClient(RunContext runContext) throws IllegalVariableEvaluationException {
+        String rKestraUrl;
+        try {
+            rKestraUrl = runContext.render("{{ kestra.url }}");
+        } catch (IllegalVariableEvaluationException e) {
+            rKestraUrl = "http://localhost:8080";
+        }
+        if (rKestraUrl == null || rKestraUrl.isBlank()) {
+            rKestraUrl = "http://localhost:8080";
+        }
+        String normalizedUrl = rKestraUrl.trim().replaceAll("/+$", "");
+        var builder = KestraClient.builder().url(normalizedUrl);
+        Optional<SDK.Auth> autoAuth = runContext.sdk().defaultAuthentication();
+        if (autoAuth.isPresent() && autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
+            return builder.basicAuth(autoAuth.get().username().get(), autoAuth.get().password().get()).build();
+        }
+        return builder.build();
     }
 
     private GitTree readGitTreeNamespaceFirst(Path baseDir) throws IOException {
@@ -692,10 +768,6 @@ public class NamespaceSync extends AbstractCloningTask implements RunnableTask<N
             } catch (IOException ignored) {
             }
         }
-    }
-
-    private void deleteFlow(RunContext rc, FlowWithSource flow) {
-        flowService(rc).delete(flow);
     }
 
     private static boolean isProtected(String namespace, List<String> protectedNamespace) {

--- a/src/main/java/io/kestra/plugin/git/NamespaceSync.java
+++ b/src/main/java/io/kestra/plugin/git/NamespaceSync.java
@@ -39,7 +39,6 @@ import io.kestra.core.models.flows.FlowWithSource;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.RunContext;
-import io.kestra.core.runners.SDK;
 import io.kestra.core.serializers.YamlParser;
 import io.kestra.core.storages.NamespaceFile;
 import io.kestra.sdk.KestraClient;
@@ -598,25 +597,6 @@ public class NamespaceSync extends AbstractCloningTask implements RunnableTask<N
         } catch (IOException e) {
             throw new KestraRuntimeException("Failed to create named file for: " + fileName, e);
         }
-    }
-
-    private KestraClient kestraClient(RunContext runContext) throws IllegalVariableEvaluationException {
-        String rKestraUrl;
-        try {
-            rKestraUrl = runContext.render("{{ kestra.url }}");
-        } catch (IllegalVariableEvaluationException e) {
-            rKestraUrl = "http://localhost:8080";
-        }
-        if (rKestraUrl == null || rKestraUrl.isBlank()) {
-            rKestraUrl = "http://localhost:8080";
-        }
-        String normalizedUrl = rKestraUrl.trim().replaceAll("/+$", "");
-        var builder = KestraClient.builder().url(normalizedUrl);
-        Optional<SDK.Auth> autoAuth = runContext.sdk().defaultAuthentication();
-        if (autoAuth.isPresent() && autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
-            return builder.basicAuth(autoAuth.get().username().get(), autoAuth.get().password().get()).build();
-        }
-        return builder.build();
     }
 
     private GitTree readGitTreeNamespaceFirst(Path baseDir) throws IOException {

--- a/src/main/java/io/kestra/plugin/git/Push.java
+++ b/src/main/java/io/kestra/plugin/git/Push.java
@@ -1,10 +1,14 @@
 package io.kestra.plugin.git;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.*;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
 
 import org.apache.commons.io.FileUtils;
 import org.eclipse.jgit.api.AddCommand;
@@ -20,6 +24,7 @@ import org.slf4j.Logger;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.exceptions.KestraRuntimeException;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.annotations.PluginProperty;
@@ -29,11 +34,16 @@ import io.kestra.core.models.tasks.InputFilesInterface;
 import io.kestra.core.models.tasks.NamespaceFiles;
 import io.kestra.core.models.tasks.NamespaceFilesInterface;
 import io.kestra.core.models.tasks.RunnableTask;
-import io.kestra.core.repositories.FlowRepositoryInterface;
-import io.kestra.core.runners.DefaultRunContext;
 import io.kestra.core.runners.FilesService;
 import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.SDK;
+import io.kestra.core.serializers.YamlParser;
 import io.kestra.core.utils.Rethrow;
+import io.kestra.sdk.KestraClient;
+import io.kestra.sdk.internal.ApiException;
+import io.kestra.sdk.model.QueryFilter;
+import io.kestra.sdk.model.QueryFilterField;
+import io.kestra.sdk.model.QueryFilterOp;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Nullable;
@@ -278,14 +288,8 @@ public class Push extends AbstractCloningTask implements RunnableTask<Push.Outpu
             String tenantId = flowProps.get("tenantId");
             String namespace = flowProps.get("namespace");
 
-            FlowRepositoryInterface flowRepository = ((DefaultRunContext) runContext).services().additionalService(FlowRepositoryInterface.class);
-
-            List<FlowWithSource> flows;
-            if (Boolean.TRUE.equals(runContext.render(this.flows.childNamespaces).as(Boolean.class).orElse(true))) {
-                flows = flowRepository.findByNamespacePrefixWithSource(tenantId, namespace);
-            } else {
-                flows = flowRepository.findByNamespaceWithSource(tenantId, namespace);
-            }
+            boolean includeChildren = Boolean.TRUE.equals(runContext.render(this.flows.childNamespaces).as(Boolean.class).orElse(true));
+            List<FlowWithSource> flows = fetchFlowsFromKestra(kestraClient(runContext), runContext, tenantId, namespace, includeChildren);
 
             Path flowsDirectory = this.flows.gitDirectory == null
                 ? basePath
@@ -339,6 +343,60 @@ public class Push extends AbstractCloningTask implements RunnableTask<Push.Outpu
                     .map(ObjectId::getName)
                     .orElse(null)
             ).build();
+    }
+
+    private List<FlowWithSource> fetchFlowsFromKestra(KestraClient kestraClient, RunContext runContext, String tenantId, String namespace, boolean includeChildren) {
+        try {
+            var op = includeChildren ? QueryFilterOp.STARTS_WITH : QueryFilterOp.EQUALS;
+            byte[] zippedFlows = kestraClient.flows().exportFlowsByQuery(
+                tenantId,
+                List.of(new QueryFilter().field(QueryFilterField.NAMESPACE).operation(op).value(namespace))
+            );
+
+            List<FlowWithSource> flows = new ArrayList<>();
+            try (
+                var bais = new ByteArrayInputStream(zippedFlows);
+                var zis = new ZipInputStream(bais)
+            ) {
+                ZipEntry entry;
+                while ((entry = zis.getNextEntry()) != null) {
+                    if (!entry.getName().endsWith(".yml") && !entry.getName().endsWith(".yaml")) {
+                        continue;
+                    }
+                    var yaml = new String(zis.readAllBytes(), StandardCharsets.UTF_8);
+                    try {
+                        var parsed = YamlParser.parse(yaml, io.kestra.core.models.flows.Flow.class);
+                        flows.add(FlowWithSource.of(parsed, yaml));
+                    } catch (Exception e) {
+                        runContext.logger().warn("Skipping invalid flow from entry {}: {}", entry.getName(), e.getMessage());
+                    }
+                }
+            }
+            return flows;
+        } catch (IOException e) {
+            throw new KestraRuntimeException("Failed to export flows from Kestra for namespace " + namespace, e);
+        } catch (ApiException e) {
+            throw new KestraRuntimeException("Failed to export flows from Kestra for namespace " + namespace, e);
+        }
+    }
+
+    private KestraClient kestraClient(RunContext runContext) throws IllegalVariableEvaluationException {
+        String rKestraUrl;
+        try {
+            rKestraUrl = runContext.render("{{ kestra.url }}");
+        } catch (IllegalVariableEvaluationException e) {
+            rKestraUrl = "http://localhost:8080";
+        }
+        if (rKestraUrl == null || rKestraUrl.isBlank()) {
+            rKestraUrl = "http://localhost:8080";
+        }
+        String normalizedUrl = rKestraUrl.trim().replaceAll("/+$", "");
+        var builder = KestraClient.builder().url(normalizedUrl);
+        Optional<SDK.Auth> autoAuth = runContext.sdk().defaultAuthentication();
+        if (autoAuth.isPresent() && autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
+            return builder.basicAuth(autoAuth.get().username().get(), autoAuth.get().password().get()).build();
+        }
+        return builder.build();
     }
 
     private PersonIdent author(RunContext runContext) throws IllegalVariableEvaluationException {

--- a/src/main/java/io/kestra/plugin/git/Push.java
+++ b/src/main/java/io/kestra/plugin/git/Push.java
@@ -301,7 +301,7 @@ public class Push extends AbstractCloningTask implements RunnableTask<Push.Outpu
                 throwConsumer(
                     flowWithSource -> FileUtils.writeStringToFile(
                         flowsDirectory.resolve(flowWithSource.getNamespace() + "." + flowWithSource.getId() + ".yml").toFile(),
-                        flowWithSource.getSource(),
+                        flowWithSource.getSource().replaceAll("(?m)^revision:\\s*\\d+\\n?", ""),
                         StandardCharsets.UTF_8
                     )
                 )

--- a/src/main/java/io/kestra/plugin/git/Push.java
+++ b/src/main/java/io/kestra/plugin/git/Push.java
@@ -36,7 +36,6 @@ import io.kestra.core.models.tasks.NamespaceFilesInterface;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.FilesService;
 import io.kestra.core.runners.RunContext;
-import io.kestra.core.runners.SDK;
 import io.kestra.core.serializers.YamlParser;
 import io.kestra.core.utils.Rethrow;
 import io.kestra.sdk.KestraClient;
@@ -378,25 +377,6 @@ public class Push extends AbstractCloningTask implements RunnableTask<Push.Outpu
         } catch (ApiException e) {
             throw new KestraRuntimeException("Failed to export flows from Kestra for namespace " + namespace, e);
         }
-    }
-
-    private KestraClient kestraClient(RunContext runContext) throws IllegalVariableEvaluationException {
-        String rKestraUrl;
-        try {
-            rKestraUrl = runContext.render("{{ kestra.url }}");
-        } catch (IllegalVariableEvaluationException e) {
-            rKestraUrl = "http://localhost:8080";
-        }
-        if (rKestraUrl == null || rKestraUrl.isBlank()) {
-            rKestraUrl = "http://localhost:8080";
-        }
-        String normalizedUrl = rKestraUrl.trim().replaceAll("/+$", "");
-        var builder = KestraClient.builder().url(normalizedUrl);
-        Optional<SDK.Auth> autoAuth = runContext.sdk().defaultAuthentication();
-        if (autoAuth.isPresent() && autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
-            return builder.basicAuth(autoAuth.get().username().get(), autoAuth.get().password().get()).build();
-        }
-        return builder.build();
     }
 
     private PersonIdent author(RunContext runContext) throws IllegalVariableEvaluationException {

--- a/src/main/java/io/kestra/plugin/git/PushDashboards.java
+++ b/src/main/java/io/kestra/plugin/git/PushDashboards.java
@@ -174,12 +174,31 @@ public class PushDashboards extends AbstractPushTask<PushDashboards.Output> {
             : "/api/v1/" + tenantId + "/dashboards/" + encodedId;
 
         HttpConfiguration.HttpConfigurationBuilder configBuilder = HttpConfiguration.builder();
-        Optional<SDK.Auth> autoAuth = runContext.sdk().defaultAuthentication();
-        if (autoAuth.isPresent() && autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
-            configBuilder.auth(BasicAuthConfiguration.builder()
-                .username(Property.ofValue(autoAuth.get().username().get()))
-                .password(Property.ofValue(autoAuth.get().password().get()))
-                .build());
+        if (auth != null) {
+            Optional<String> maybeUsername = runContext.render(auth.getUsername()).as(String.class);
+            Optional<String> maybePassword = runContext.render(auth.getPassword()).as(String.class);
+            if (maybeUsername.isPresent() && maybePassword.isPresent()) {
+                configBuilder.auth(BasicAuthConfiguration.builder()
+                    .username(Property.ofValue(maybeUsername.get()))
+                    .password(Property.ofValue(maybePassword.get()))
+                    .build());
+            } else if (runContext.render(auth.getAuto()).as(Boolean.class).orElse(Boolean.TRUE)) {
+                Optional<SDK.Auth> autoAuth = runContext.sdk().defaultAuthentication();
+                if (autoAuth.isPresent() && autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
+                    configBuilder.auth(BasicAuthConfiguration.builder()
+                        .username(Property.ofValue(autoAuth.get().username().get()))
+                        .password(Property.ofValue(autoAuth.get().password().get()))
+                        .build());
+                }
+            }
+        } else {
+            Optional<SDK.Auth> autoAuth = runContext.sdk().defaultAuthentication();
+            if (autoAuth.isPresent() && autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
+                configBuilder.auth(BasicAuthConfiguration.builder()
+                    .username(Property.ofValue(autoAuth.get().username().get()))
+                    .password(Property.ofValue(autoAuth.get().password().get()))
+                    .build());
+            }
         }
 
         try (var httpClient = HttpClient.builder()

--- a/src/main/java/io/kestra/plugin/git/PushDashboards.java
+++ b/src/main/java/io/kestra/plugin/git/PushDashboards.java
@@ -1,16 +1,17 @@
 package io.kestra.plugin.git;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -18,23 +19,20 @@ import java.util.stream.Stream;
 import com.google.common.annotations.VisibleForTesting;
 
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.exceptions.KestraRuntimeException;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.annotations.PluginProperty;
-import io.kestra.core.models.dashboards.Dashboard;
 import io.kestra.core.models.property.Property;
-import io.kestra.core.repositories.ArrayListTotal;
-import io.kestra.core.repositories.DashboardRepositoryInterface;
-import io.micronaut.data.model.Pageable;
-import io.kestra.core.runners.DefaultRunContext;
 import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.SDK;
+import io.kestra.sdk.KestraClient;
+import io.kestra.sdk.model.PagedResultsDashboard;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 
-import static io.kestra.core.utils.Rethrow.throwFunction;
-import static io.kestra.core.utils.Rethrow.throwSupplier;
 
 @SuperBuilder(toBuilder = true)
 @ToString
@@ -123,21 +121,25 @@ public class PushDashboards extends AbstractPushTask<PushDashboards.Output> {
     }
 
     protected Map<Path, Supplier<InputStream>> instanceResourcesContentByPath(RunContext runContext, Path flowDirectory, List<String> globs) throws IllegalVariableEvaluationException {
-        DashboardRepositoryInterface dashboardRepository = ((DefaultRunContext) runContext).services().additionalService(DashboardRepositoryInterface.class);
-
         Map<String, String> flowProps = Optional.ofNullable((Map<String, String>) runContext.getVariables().get("flow")).orElse(Collections.emptyMap());
         String tenantId = flowProps.get("tenantId");
+        KestraClient kestraClient = kestraClient(runContext);
 
-        List<Dashboard> dashboardsToPush = new ArrayList<>();
-        final int pageSize = 100;
+        List<io.kestra.sdk.model.Dashboard> allDashboards = new ArrayList<>();
         int page = 1;
-        ArrayListTotal<Dashboard> pageResult;
+        int size = 200;
+        PagedResultsDashboard pagedResults;
         do {
-            pageResult = dashboardRepository.list(Pageable.from(page++, pageSize), tenantId, null);
-            dashboardsToPush.addAll(pageResult);
-        } while (dashboardsToPush.size() < pageResult.getTotal());
+            try {
+                pagedResults = kestraClient.dashboards().searchDashboards(page, size, tenantId, null, null);
+            } catch (Exception e) {
+                throw new KestraRuntimeException("Failed to fetch dashboards from Kestra", e);
+            }
+            allDashboards.addAll(pagedResults.getResults());
+            page++;
+        } while (pagedResults.getResults().size() == size);
 
-        Stream<Dashboard> dashboardStream = dashboardsToPush.stream();
+        Stream<io.kestra.sdk.model.Dashboard> dashboardStream = allDashboards.stream();
         if (globs != null) {
             List<PathMatcher> matchers = globs.stream().map(glob -> FileSystems.getDefault().getPathMatcher("glob:" + glob)).toList();
             dashboardStream = dashboardStream.filter(dashboard ->
@@ -147,13 +149,66 @@ public class PushDashboards extends AbstractPushTask<PushDashboards.Output> {
             });
         }
 
-        return dashboardStream.collect(Collectors.toMap(dashboard ->
-        {
-            Path path = flowDirectory;
-            return path.resolve(dashboard.getId() + ".yml");
-        },
-            throwFunction(dashboard -> (throwSupplier(() -> new ByteArrayInputStream(dashboard.getSourceCode().getBytes()))))
+        return dashboardStream.collect(Collectors.toMap(
+            dashboard -> flowDirectory.resolve(dashboard.getId() + ".yml"),
+            dashboard -> () ->
+            {
+                try {
+                    String sourceCode = fetchDashboardSourceCode(kestraClient, runContext, tenantId, dashboard.getId());
+                    return new ByteArrayInputStream(sourceCode.getBytes(StandardCharsets.UTF_8));
+                } catch (Exception e) {
+                    throw new KestraRuntimeException("Failed to fetch dashboard source for " + dashboard.getId(), e);
+                }
+            }
         ));
+    }
+
+    private String fetchDashboardSourceCode(KestraClient kestraClient, RunContext runContext, String tenantId, String dashboardId) throws Exception {
+        var apiClient = kestraClient.dashboards().getApiClient();
+        String path = tenantId == null
+            ? "/api/v1/dashboards/" + dashboardId
+            : "/api/v1/" + tenantId + "/dashboards/" + dashboardId;
+        String url = apiClient.getBaseURL() + path;
+
+        var requestBuilder = HttpRequest.newBuilder()
+            .uri(java.net.URI.create(url))
+            .header("Accept", "application/x-yaml")
+            .GET();
+
+        var autoAuth = runContext.sdk().defaultAuthentication();
+        if (autoAuth.isPresent() && autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
+            String encoded = Base64.getEncoder().encodeToString(
+                (autoAuth.get().username().get() + ":" + autoAuth.get().password().get()).getBytes(StandardCharsets.UTF_8));
+            requestBuilder.header("Authorization", "Basic " + encoded);
+        }
+
+        var response = HttpClient.newHttpClient().send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() == 401) {
+            throw new KestraRuntimeException("Authentication required to fetch dashboard YAML for " + dashboardId + ". Check your Kestra credentials.");
+        }
+        if (response.statusCode() != 200) {
+            throw new KestraRuntimeException("Failed to fetch dashboard YAML for " + dashboardId + ": HTTP " + response.statusCode());
+        }
+        return response.body();
+    }
+
+    private KestraClient kestraClient(RunContext runContext) throws IllegalVariableEvaluationException {
+        String rKestraUrl;
+        try {
+            rKestraUrl = runContext.render("{{ kestra.url }}");
+        } catch (IllegalVariableEvaluationException e) {
+            rKestraUrl = "http://localhost:8080";
+        }
+        if (rKestraUrl == null || rKestraUrl.isBlank()) {
+            rKestraUrl = "http://localhost:8080";
+        }
+        String normalizedUrl = rKestraUrl.trim().replaceAll("/+$", "");
+        var builder = KestraClient.builder().url(normalizedUrl);
+        Optional<SDK.Auth> autoAuth = runContext.sdk().defaultAuthentication();
+        if (autoAuth.isPresent() && autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
+            return builder.basicAuth(autoAuth.get().username().get(), autoAuth.get().password().get()).build();
+        }
+        return builder.build();
     }
 
     @Override

--- a/src/main/java/io/kestra/plugin/git/PushDashboards.java
+++ b/src/main/java/io/kestra/plugin/git/PushDashboards.java
@@ -1,7 +1,6 @@
 package io.kestra.plugin.git;
 
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URLEncoder;
@@ -14,20 +13,18 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.annotations.VisibleForTesting;
 
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.exceptions.KestraRuntimeException;
-import io.kestra.core.http.HttpRequest;
-import io.kestra.core.http.client.HttpClient;
-import io.kestra.core.http.client.configurations.HttpConfiguration;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
-import io.kestra.core.runners.SDK;
 import io.kestra.sdk.KestraClient;
+import io.kestra.sdk.internal.ApiClient;
 import io.kestra.sdk.model.PagedResultsDashboard;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -166,61 +163,20 @@ public class PushDashboards extends AbstractPushTask<PushDashboards.Output> {
     }
 
     private String fetchDashboardSourceCode(KestraClient kestraClient, RunContext runContext, String tenantId, String dashboardId) throws Exception {
-        String basePath = kestraClient.dashboards().getApiClient().getBasePath();
+        ApiClient apiClient = kestraClient.dashboards().getApiClient();
         String encodedId = URLEncoder.encode(dashboardId, StandardCharsets.UTF_8);
         String path = tenantId == null
             ? "/api/v1/dashboards/" + encodedId
             : "/api/v1/" + tenantId + "/dashboards/" + encodedId;
 
-        String username = null;
-        String password = null;
-        String apiToken = null;
-        if (auth != null) {
-            Optional<String> maybeUsername = runContext.render(auth.getUsername()).as(String.class);
-            Optional<String> maybePassword = runContext.render(auth.getPassword()).as(String.class);
-            if (maybeUsername.isPresent() && maybePassword.isPresent()) {
-                username = maybeUsername.get();
-                password = maybePassword.get();
-            } else if (runContext.render(auth.getAuto()).as(Boolean.class).orElse(Boolean.TRUE)) {
-                Optional<SDK.Auth> autoAuth = runContext.sdk().defaultAuthentication();
-                if (autoAuth.isPresent()) {
-                    if (autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
-                        username = autoAuth.get().username().get();
-                        password = autoAuth.get().password().get();
-                    } else if (autoAuth.get().apiToken().isPresent()) {
-                        apiToken = autoAuth.get().apiToken().get();
-                    }
-                }
-            }
-        } else {
-            Optional<SDK.Auth> autoAuth = runContext.sdk().defaultAuthentication();
-            if (autoAuth.isPresent()) {
-                if (autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
-                    username = autoAuth.get().username().get();
-                    password = autoAuth.get().password().get();
-                } else if (autoAuth.get().apiToken().isPresent()) {
-                    apiToken = autoAuth.get().apiToken().get();
-                }
-            }
-        }
-
-        HttpRequest.HttpRequestBuilder requestBuilder = HttpRequest.builder()
-            .uri(URI.create(basePath + path))
-            .addHeader("Accept", "application/x-yaml");
-        if (username != null && password != null) {
-            String encoded = Base64.getEncoder().encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
-            requestBuilder.addHeader("Authorization", "Basic " + encoded);
-        } else if (apiToken != null) {
-            requestBuilder.addHeader("Authorization", "Bearer " + apiToken);
-        }
-
-        try (var httpClient = HttpClient.builder()
-                .runContext(runContext)
-                .configuration(HttpConfiguration.builder().build())
-                .build()) {
-            var response = httpClient.request(requestBuilder.build(), String.class);
-            return response.getBody();
-        }
+        byte[] yamlBytes = apiClient.invokeAPI(
+            path, "GET",
+            Collections.emptyList(), Collections.emptyList(), null,
+            null, Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
+            "application/x-yaml", null, new String[0],
+            new TypeReference<byte[]>() {}
+        );
+        return new String(yamlBytes, StandardCharsets.UTF_8);
     }
 
     @Override

--- a/src/main/java/io/kestra/plugin/git/PushDashboards.java
+++ b/src/main/java/io/kestra/plugin/git/PushDashboards.java
@@ -25,7 +25,6 @@ import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
-import io.kestra.core.runners.SDK;
 import io.kestra.sdk.KestraClient;
 import io.kestra.sdk.model.PagedResultsDashboard;
 
@@ -190,25 +189,6 @@ public class PushDashboards extends AbstractPushTask<PushDashboards.Output> {
             throw new KestraRuntimeException("Failed to fetch dashboard YAML for " + dashboardId + ": HTTP " + response.statusCode());
         }
         return response.body();
-    }
-
-    private KestraClient kestraClient(RunContext runContext) throws IllegalVariableEvaluationException {
-        String rKestraUrl;
-        try {
-            rKestraUrl = runContext.render("{{ kestra.url }}");
-        } catch (IllegalVariableEvaluationException e) {
-            rKestraUrl = "http://localhost:8080";
-        }
-        if (rKestraUrl == null || rKestraUrl.isBlank()) {
-            rKestraUrl = "http://localhost:8080";
-        }
-        String normalizedUrl = rKestraUrl.trim().replaceAll("/+$", "");
-        var builder = KestraClient.builder().url(normalizedUrl);
-        Optional<SDK.Auth> autoAuth = runContext.sdk().defaultAuthentication();
-        if (autoAuth.isPresent() && autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
-            return builder.basicAuth(autoAuth.get().username().get(), autoAuth.get().password().get()).build();
-        }
-        return builder.build();
     }
 
     @Override

--- a/src/main/java/io/kestra/plugin/git/PushDashboards.java
+++ b/src/main/java/io/kestra/plugin/git/PushDashboards.java
@@ -169,14 +169,14 @@ public class PushDashboards extends AbstractPushTask<PushDashboards.Output> {
             ? "/api/v1/dashboards/" + encodedId
             : "/api/v1/" + tenantId + "/dashboards/" + encodedId;
 
-        byte[] yamlBytes = apiClient.invokeAPI(
+        Map<String, Object> response = apiClient.invokeAPI(
             path, "GET",
             Collections.emptyList(), Collections.emptyList(), null,
             null, Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
-            "application/x-yaml", null, new String[0],
-            new TypeReference<byte[]>() {}
+            "application/json", null, new String[0],
+            new TypeReference<Map<String, Object>>() {}
         );
-        return new String(yamlBytes, StandardCharsets.UTF_8);
+        return (String) response.get("sourceCode");
     }
 
     @Override

--- a/src/main/java/io/kestra/plugin/git/PushDashboards.java
+++ b/src/main/java/io/kestra/plugin/git/PushDashboards.java
@@ -1,6 +1,7 @@
 package io.kestra.plugin.git;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URLEncoder;
@@ -13,18 +14,20 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.annotations.VisibleForTesting;
 
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.exceptions.KestraRuntimeException;
+import io.kestra.core.http.HttpRequest;
+import io.kestra.core.http.client.HttpClient;
+import io.kestra.core.http.client.configurations.HttpConfiguration;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.SDK;
 import io.kestra.sdk.KestraClient;
-import io.kestra.sdk.internal.ApiClient;
 import io.kestra.sdk.model.PagedResultsDashboard;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -163,20 +166,61 @@ public class PushDashboards extends AbstractPushTask<PushDashboards.Output> {
     }
 
     private String fetchDashboardSourceCode(KestraClient kestraClient, RunContext runContext, String tenantId, String dashboardId) throws Exception {
-        ApiClient apiClient = kestraClient.dashboards().getApiClient();
+        String basePath = kestraClient.dashboards().getApiClient().getBasePath();
         String encodedId = URLEncoder.encode(dashboardId, StandardCharsets.UTF_8);
         String path = tenantId == null
             ? "/api/v1/dashboards/" + encodedId
             : "/api/v1/" + tenantId + "/dashboards/" + encodedId;
 
-        byte[] yamlBytes = apiClient.invokeAPI(
-            path, "GET",
-            Collections.emptyList(), Collections.emptyList(), null,
-            null, Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
-            "application/x-yaml", null, new String[0],
-            new TypeReference<byte[]>() {}
-        );
-        return new String(yamlBytes, StandardCharsets.UTF_8);
+        String username = null;
+        String password = null;
+        String apiToken = null;
+        if (auth != null) {
+            Optional<String> maybeUsername = runContext.render(auth.getUsername()).as(String.class);
+            Optional<String> maybePassword = runContext.render(auth.getPassword()).as(String.class);
+            if (maybeUsername.isPresent() && maybePassword.isPresent()) {
+                username = maybeUsername.get();
+                password = maybePassword.get();
+            } else if (runContext.render(auth.getAuto()).as(Boolean.class).orElse(Boolean.TRUE)) {
+                Optional<SDK.Auth> autoAuth = runContext.sdk().defaultAuthentication();
+                if (autoAuth.isPresent()) {
+                    if (autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
+                        username = autoAuth.get().username().get();
+                        password = autoAuth.get().password().get();
+                    } else if (autoAuth.get().apiToken().isPresent()) {
+                        apiToken = autoAuth.get().apiToken().get();
+                    }
+                }
+            }
+        } else {
+            Optional<SDK.Auth> autoAuth = runContext.sdk().defaultAuthentication();
+            if (autoAuth.isPresent()) {
+                if (autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
+                    username = autoAuth.get().username().get();
+                    password = autoAuth.get().password().get();
+                } else if (autoAuth.get().apiToken().isPresent()) {
+                    apiToken = autoAuth.get().apiToken().get();
+                }
+            }
+        }
+
+        HttpRequest.HttpRequestBuilder requestBuilder = HttpRequest.builder()
+            .uri(URI.create(basePath + path))
+            .addHeader("Accept", "application/x-yaml");
+        if (username != null && password != null) {
+            String encoded = Base64.getEncoder().encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
+            requestBuilder.addHeader("Authorization", "Basic " + encoded);
+        } else if (apiToken != null) {
+            requestBuilder.addHeader("Authorization", "Bearer " + apiToken);
+        }
+
+        try (var httpClient = HttpClient.builder()
+                .runContext(runContext)
+                .configuration(HttpConfiguration.builder().build())
+                .build()) {
+            var response = httpClient.request(requestBuilder.build(), String.class);
+            return response.getBody();
+        }
     }
 
     @Override

--- a/src/main/java/io/kestra/plugin/git/PushDashboards.java
+++ b/src/main/java/io/kestra/plugin/git/PushDashboards.java
@@ -154,7 +154,8 @@ public class PushDashboards extends AbstractPushTask<PushDashboards.Output> {
             {
                 try {
                     String sourceCode = fetchDashboardSourceCode(kestraClient, runContext, tenantId, dashboard.getId());
-                    return new ByteArrayInputStream(sourceCode.getBytes(StandardCharsets.UTF_8));
+                    String cleanSourceCode = sourceCode.replaceAll("(?m)^updated:.*\\R?", "");
+                    return new ByteArrayInputStream(cleanSourceCode.getBytes(StandardCharsets.UTF_8));
                 } catch (Exception e) {
                     throw new KestraRuntimeException("Failed to fetch dashboard source for " + dashboard.getId(), e);
                 }

--- a/src/main/java/io/kestra/plugin/git/PushDashboards.java
+++ b/src/main/java/io/kestra/plugin/git/PushDashboards.java
@@ -4,9 +4,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
+import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
@@ -20,11 +18,16 @@ import com.google.common.annotations.VisibleForTesting;
 
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.exceptions.KestraRuntimeException;
+import io.kestra.core.http.HttpRequest;
+import io.kestra.core.http.client.HttpClient;
+import io.kestra.core.http.client.configurations.BasicAuthConfiguration;
+import io.kestra.core.http.client.configurations.HttpConfiguration;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.SDK;
 import io.kestra.sdk.KestraClient;
 import io.kestra.sdk.model.PagedResultsDashboard;
 
@@ -164,32 +167,34 @@ public class PushDashboards extends AbstractPushTask<PushDashboards.Output> {
     }
 
     private String fetchDashboardSourceCode(KestraClient kestraClient, RunContext runContext, String tenantId, String dashboardId) throws Exception {
-        var apiClient = kestraClient.dashboards().getApiClient();
+        String basePath = kestraClient.dashboards().getApiClient().getBasePath();
+        String encodedId = URLEncoder.encode(dashboardId, StandardCharsets.UTF_8);
         String path = tenantId == null
-            ? "/api/v1/dashboards/" + dashboardId
-            : "/api/v1/" + tenantId + "/dashboards/" + dashboardId;
-        String url = apiClient.getBaseURL() + path;
+            ? "/api/v1/dashboards/" + encodedId
+            : "/api/v1/" + tenantId + "/dashboards/" + encodedId;
 
-        var requestBuilder = HttpRequest.newBuilder()
-            .uri(java.net.URI.create(url))
-            .header("Accept", "application/x-yaml")
-            .GET();
-
-        var autoAuth = runContext.sdk().defaultAuthentication();
+        HttpConfiguration.HttpConfigurationBuilder configBuilder = HttpConfiguration.builder();
+        Optional<SDK.Auth> autoAuth = runContext.sdk().defaultAuthentication();
         if (autoAuth.isPresent() && autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
-            String encoded = Base64.getEncoder().encodeToString(
-                (autoAuth.get().username().get() + ":" + autoAuth.get().password().get()).getBytes(StandardCharsets.UTF_8));
-            requestBuilder.header("Authorization", "Basic " + encoded);
+            configBuilder.auth(BasicAuthConfiguration.builder()
+                .username(Property.ofValue(autoAuth.get().username().get()))
+                .password(Property.ofValue(autoAuth.get().password().get()))
+                .build());
         }
 
-        var response = HttpClient.newHttpClient().send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString());
-        if (response.statusCode() == 401) {
-            throw new KestraRuntimeException("Authentication required to fetch dashboard YAML for " + dashboardId + ". Check your Kestra credentials.");
+        try (var httpClient = HttpClient.builder()
+                .runContext(runContext)
+                .configuration(configBuilder.build())
+                .build()) {
+            var response = httpClient.request(
+                HttpRequest.builder()
+                    .uri(URI.create(basePath + path))
+                    .addHeader("Accept", "application/x-yaml")
+                    .build(),
+                String.class
+            );
+            return response.getBody();
         }
-        if (response.statusCode() != 200) {
-            throw new KestraRuntimeException("Failed to fetch dashboard YAML for " + dashboardId + ": HTTP " + response.statusCode());
-        }
-        return response.body();
     }
 
     @Override

--- a/src/main/java/io/kestra/plugin/git/PushDashboards.java
+++ b/src/main/java/io/kestra/plugin/git/PushDashboards.java
@@ -20,7 +20,6 @@ import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.exceptions.KestraRuntimeException;
 import io.kestra.core.http.HttpRequest;
 import io.kestra.core.http.client.HttpClient;
-import io.kestra.core.http.client.configurations.BasicAuthConfiguration;
 import io.kestra.core.http.client.configurations.HttpConfiguration;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
@@ -173,45 +172,42 @@ public class PushDashboards extends AbstractPushTask<PushDashboards.Output> {
             ? "/api/v1/dashboards/" + encodedId
             : "/api/v1/" + tenantId + "/dashboards/" + encodedId;
 
-        HttpConfiguration.HttpConfigurationBuilder configBuilder = HttpConfiguration.builder();
+        String username = null;
+        String password = null;
         if (auth != null) {
             Optional<String> maybeUsername = runContext.render(auth.getUsername()).as(String.class);
             Optional<String> maybePassword = runContext.render(auth.getPassword()).as(String.class);
             if (maybeUsername.isPresent() && maybePassword.isPresent()) {
-                configBuilder.auth(BasicAuthConfiguration.builder()
-                    .username(Property.ofValue(maybeUsername.get()))
-                    .password(Property.ofValue(maybePassword.get()))
-                    .build());
+                username = maybeUsername.get();
+                password = maybePassword.get();
             } else if (runContext.render(auth.getAuto()).as(Boolean.class).orElse(Boolean.TRUE)) {
                 Optional<SDK.Auth> autoAuth = runContext.sdk().defaultAuthentication();
                 if (autoAuth.isPresent() && autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
-                    configBuilder.auth(BasicAuthConfiguration.builder()
-                        .username(Property.ofValue(autoAuth.get().username().get()))
-                        .password(Property.ofValue(autoAuth.get().password().get()))
-                        .build());
+                    username = autoAuth.get().username().get();
+                    password = autoAuth.get().password().get();
                 }
             }
         } else {
             Optional<SDK.Auth> autoAuth = runContext.sdk().defaultAuthentication();
             if (autoAuth.isPresent() && autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
-                configBuilder.auth(BasicAuthConfiguration.builder()
-                    .username(Property.ofValue(autoAuth.get().username().get()))
-                    .password(Property.ofValue(autoAuth.get().password().get()))
-                    .build());
+                username = autoAuth.get().username().get();
+                password = autoAuth.get().password().get();
             }
+        }
+
+        HttpRequest.HttpRequestBuilder requestBuilder = HttpRequest.builder()
+            .uri(URI.create(basePath + path))
+            .addHeader("Accept", "application/x-yaml");
+        if (username != null && password != null) {
+            String encoded = Base64.getEncoder().encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
+            requestBuilder.addHeader("Authorization", "Basic " + encoded);
         }
 
         try (var httpClient = HttpClient.builder()
                 .runContext(runContext)
-                .configuration(configBuilder.build())
+                .configuration(HttpConfiguration.builder().build())
                 .build()) {
-            var response = httpClient.request(
-                HttpRequest.builder()
-                    .uri(URI.create(basePath + path))
-                    .addHeader("Accept", "application/x-yaml")
-                    .build(),
-                String.class
-            );
+            var response = httpClient.request(requestBuilder.build(), String.class);
             return response.getBody();
         }
     }

--- a/src/main/java/io/kestra/plugin/git/PushDashboards.java
+++ b/src/main/java/io/kestra/plugin/git/PushDashboards.java
@@ -174,6 +174,7 @@ public class PushDashboards extends AbstractPushTask<PushDashboards.Output> {
 
         String username = null;
         String password = null;
+        String apiToken = null;
         if (auth != null) {
             Optional<String> maybeUsername = runContext.render(auth.getUsername()).as(String.class);
             Optional<String> maybePassword = runContext.render(auth.getPassword()).as(String.class);
@@ -182,16 +183,24 @@ public class PushDashboards extends AbstractPushTask<PushDashboards.Output> {
                 password = maybePassword.get();
             } else if (runContext.render(auth.getAuto()).as(Boolean.class).orElse(Boolean.TRUE)) {
                 Optional<SDK.Auth> autoAuth = runContext.sdk().defaultAuthentication();
-                if (autoAuth.isPresent() && autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
-                    username = autoAuth.get().username().get();
-                    password = autoAuth.get().password().get();
+                if (autoAuth.isPresent()) {
+                    if (autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
+                        username = autoAuth.get().username().get();
+                        password = autoAuth.get().password().get();
+                    } else if (autoAuth.get().apiToken().isPresent()) {
+                        apiToken = autoAuth.get().apiToken().get();
+                    }
                 }
             }
         } else {
             Optional<SDK.Auth> autoAuth = runContext.sdk().defaultAuthentication();
-            if (autoAuth.isPresent() && autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
-                username = autoAuth.get().username().get();
-                password = autoAuth.get().password().get();
+            if (autoAuth.isPresent()) {
+                if (autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
+                    username = autoAuth.get().username().get();
+                    password = autoAuth.get().password().get();
+                } else if (autoAuth.get().apiToken().isPresent()) {
+                    apiToken = autoAuth.get().apiToken().get();
+                }
             }
         }
 
@@ -201,6 +210,8 @@ public class PushDashboards extends AbstractPushTask<PushDashboards.Output> {
         if (username != null && password != null) {
             String encoded = Base64.getEncoder().encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
             requestBuilder.addHeader("Authorization", "Basic " + encoded);
+        } else if (apiToken != null) {
+            requestBuilder.addHeader("Authorization", "Bearer " + apiToken);
         }
 
         try (var httpClient = HttpClient.builder()

--- a/src/main/java/io/kestra/plugin/git/PushFlows.java
+++ b/src/main/java/io/kestra/plugin/git/PushFlows.java
@@ -25,7 +25,6 @@ import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.flows.FlowWithSource;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
-import io.kestra.core.runners.SDK;
 import io.kestra.core.serializers.YamlParser;
 import io.kestra.sdk.KestraClient;
 import io.kestra.sdk.internal.ApiException;
@@ -257,25 +256,6 @@ public class PushFlows extends AbstractPushTask<PushFlows.Output> {
         } catch (ApiException e) {
             throw new KestraRuntimeException("Failed to export flows from Kestra for namespace " + namespace, e);
         }
-    }
-
-    private KestraClient kestraClient(RunContext runContext) throws IllegalVariableEvaluationException {
-        String rKestraUrl;
-        try {
-            rKestraUrl = runContext.render("{{ kestra.url }}");
-        } catch (IllegalVariableEvaluationException e) {
-            rKestraUrl = "http://localhost:8080";
-        }
-        if (rKestraUrl == null || rKestraUrl.isBlank()) {
-            rKestraUrl = "http://localhost:8080";
-        }
-        String normalizedUrl = rKestraUrl.trim().replaceAll("/+$", "");
-        var builder = KestraClient.builder().url(normalizedUrl);
-        Optional<SDK.Auth> autoAuth = runContext.sdk().defaultAuthentication();
-        if (autoAuth.isPresent() && autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
-            return builder.basicAuth(autoAuth.get().username().get(), autoAuth.get().password().get()).build();
-        }
-        return builder.build();
     }
 
     @Override

--- a/src/main/java/io/kestra/plugin/git/PushFlows.java
+++ b/src/main/java/io/kestra/plugin/git/PushFlows.java
@@ -1,8 +1,10 @@
 package io.kestra.plugin.git;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
@@ -10,18 +12,26 @@ import java.util.*;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
 
 import com.google.common.annotations.VisibleForTesting;
 
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.exceptions.KestraRuntimeException;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.flows.FlowWithSource;
 import io.kestra.core.models.property.Property;
-import io.kestra.core.repositories.FlowRepositoryInterface;
-import io.kestra.core.runners.DefaultRunContext;
 import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.SDK;
+import io.kestra.core.serializers.YamlParser;
+import io.kestra.sdk.KestraClient;
+import io.kestra.sdk.internal.ApiException;
+import io.kestra.sdk.model.QueryFilter;
+import io.kestra.sdk.model.QueryFilterField;
+import io.kestra.sdk.model.QueryFilterOp;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
@@ -177,17 +187,12 @@ public class PushFlows extends AbstractPushTask<PushFlows.Output> {
     }
 
     protected Map<Path, Supplier<InputStream>> instanceResourcesContentByPath(RunContext runContext, Path flowDirectory, List<String> globs) throws IllegalVariableEvaluationException {
-        FlowRepositoryInterface flowRepository = ((DefaultRunContext) runContext).services().additionalService(FlowRepositoryInterface.class);
-
         Map<String, String> flowProps = Optional.ofNullable((Map<String, String>) runContext.getVariables().get("flow")).orElse(Collections.emptyMap());
         String tenantId = flowProps.get("tenantId");
-        List<FlowWithSource> flowsToPush;
         String renderedSourceNamespace = runContext.render(this.sourceNamespace).as(String.class).orElse(null);
-        if (Boolean.TRUE.equals(runContext.render(this.includeChildNamespaces).as(Boolean.class).orElseThrow())) {
-            flowsToPush = flowRepository.findByNamespacePrefixWithSource(tenantId, renderedSourceNamespace);
-        } else {
-            flowsToPush = flowRepository.findByNamespaceWithSource(tenantId, renderedSourceNamespace);
-        }
+        boolean includeChildren = Boolean.TRUE.equals(runContext.render(this.includeChildNamespaces).as(Boolean.class).orElseThrow());
+
+        List<FlowWithSource> flowsToPush = fetchFlowsFromKestra(kestraClient(runContext), runContext, tenantId, renderedSourceNamespace, includeChildren);
 
         Stream<FlowWithSource> filteredFlowsToPush = flowsToPush.stream();
         if (globs != null) {
@@ -217,6 +222,60 @@ public class PushFlows extends AbstractPushTask<PushFlows.Output> {
                 );
             return new ByteArrayInputStream(modifiedSource.getBytes());
         })))));
+    }
+
+    private List<FlowWithSource> fetchFlowsFromKestra(KestraClient kestraClient, RunContext runContext, String tenantId, String namespace, boolean includeChildren) {
+        try {
+            var op = includeChildren ? QueryFilterOp.STARTS_WITH : QueryFilterOp.EQUALS;
+            byte[] zippedFlows = kestraClient.flows().exportFlowsByQuery(
+                tenantId,
+                List.of(new QueryFilter().field(QueryFilterField.NAMESPACE).operation(op).value(namespace))
+            );
+
+            List<FlowWithSource> flows = new ArrayList<>();
+            try (
+                var bais = new ByteArrayInputStream(zippedFlows);
+                var zis = new ZipInputStream(bais)
+            ) {
+                ZipEntry entry;
+                while ((entry = zis.getNextEntry()) != null) {
+                    if (!entry.getName().endsWith(".yml") && !entry.getName().endsWith(".yaml")) {
+                        continue;
+                    }
+                    var yaml = new String(zis.readAllBytes(), StandardCharsets.UTF_8);
+                    try {
+                        var parsed = YamlParser.parse(yaml, io.kestra.core.models.flows.Flow.class);
+                        flows.add(FlowWithSource.of(parsed, yaml));
+                    } catch (Exception e) {
+                        runContext.logger().warn("Skipping invalid flow from entry {}: {}", entry.getName(), e.getMessage());
+                    }
+                }
+            }
+            return flows;
+        } catch (IOException e) {
+            throw new KestraRuntimeException("Failed to export flows from Kestra for namespace " + namespace, e);
+        } catch (ApiException e) {
+            throw new KestraRuntimeException("Failed to export flows from Kestra for namespace " + namespace, e);
+        }
+    }
+
+    private KestraClient kestraClient(RunContext runContext) throws IllegalVariableEvaluationException {
+        String rKestraUrl;
+        try {
+            rKestraUrl = runContext.render("{{ kestra.url }}");
+        } catch (IllegalVariableEvaluationException e) {
+            rKestraUrl = "http://localhost:8080";
+        }
+        if (rKestraUrl == null || rKestraUrl.isBlank()) {
+            rKestraUrl = "http://localhost:8080";
+        }
+        String normalizedUrl = rKestraUrl.trim().replaceAll("/+$", "");
+        var builder = KestraClient.builder().url(normalizedUrl);
+        Optional<SDK.Auth> autoAuth = runContext.sdk().defaultAuthentication();
+        if (autoAuth.isPresent() && autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
+            return builder.basicAuth(autoAuth.get().username().get(), autoAuth.get().password().get()).build();
+        }
+        return builder.build();
     }
 
     @Override

--- a/src/main/java/io/kestra/plugin/git/PushFlows.java
+++ b/src/main/java/io/kestra/plugin/git/PushFlows.java
@@ -215,6 +215,7 @@ public class PushFlows extends AbstractPushTask<PushFlows.Output> {
         {
             String renderedTargetNamespace = runContext.render(targetNamespace).as(String.class).orElse(renderedSourceNamespace);
             String modifiedSource = flowWithSource.getSource()
+                .replaceAll("(?m)^revision:\\s*\\d+\\n?", "")  // strip server-side revision before writing to git
                 .replaceAll(
                     "(?m)^(\\s*namespace:\\s*)" + renderedSourceNamespace,
                     "$1" + renderedTargetNamespace

--- a/src/main/java/io/kestra/plugin/git/Sync.java
+++ b/src/main/java/io/kestra/plugin/git/Sync.java
@@ -2,7 +2,9 @@ package io.kestra.plugin.git;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
@@ -11,24 +13,33 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 
+import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.exceptions.KestraRuntimeException;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.flows.FlowWithSource;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.models.tasks.VoidOutput;
-import io.kestra.core.repositories.FlowRepositoryInterface;
 import io.kestra.core.runners.DefaultRunContext;
 import io.kestra.core.runners.RunContext;
-import io.kestra.core.services.FlowService;
+import io.kestra.core.runners.SDK;
+import io.kestra.core.serializers.YamlParser;
 import io.kestra.core.storages.StorageContext;
 import io.kestra.core.storages.StorageInterface;
 import io.kestra.core.utils.KestraIgnore;
+import io.kestra.sdk.KestraClient;
+import io.kestra.sdk.internal.ApiException;
+import io.kestra.sdk.model.QueryFilter;
+import io.kestra.sdk.model.QueryFilterField;
+import io.kestra.sdk.model.QueryFilterOp;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -143,8 +154,7 @@ public class Sync extends AbstractCloningTask implements RunnableTask<VoidOutput
         // synchronize flows directory to namespace flows
         File flowsDirectory = flowsDirectoryBasePath.toFile();
         if (flowsDirectory.exists()) {
-            FlowRepositoryInterface flowRepository = ((DefaultRunContext) runContext).services().additionalService(FlowRepositoryInterface.class);
-            FlowService flowService = ((DefaultRunContext) runContext).services().additionalService(FlowService.class);
+            KestraClient kestraClient = kestraClient(runContext);
 
             Set<String> flowIdsImported = Arrays.stream(flowsDirectory.listFiles())
                 .map(File::toPath)
@@ -171,11 +181,15 @@ public class Sync extends AbstractCloningTask implements RunnableTask<VoidOutput
                         Matcher matcher = FLOW_ID_FINDER_PATTERN.matcher(flowSource);
                         matcher.find();
                         String flowId = matcher.group(1).trim();
-                        isAddition = flowRepository.findById(tenantId, flowSourceByNamespace.getKey(), flowId).isEmpty();
+                        isAddition = fetchSingleFlow(kestraClient, tenantId, flowSourceByNamespace.getKey(), flowId) == null;
                         flowWithSource = FlowWithSource.builder().source(flowSource).id(flowId).build();
                     } else {
-                        flowWithSource = flowService.importFlow(tenantId, flowSource);
-                        isAddition = flowWithSource.getRevision() == 1;
+                        String flowId = YamlParser.parse(flowSource, io.kestra.core.models.flows.Flow.class).getId();
+                        kestraClient.flows().importFlows(false, tenantId, toNamedTempFile(flowId + ".yaml", flowSource.stripTrailing()));
+                        // Determine addition vs update by checking if revision == 1
+                        var imported = fetchSingleFlow(kestraClient, tenantId, flowSourceByNamespace.getKey(), flowId);
+                        isAddition = imported != null && imported.getRevision() != null && imported.getRevision() == 1;
+                        flowWithSource = imported != null ? imported : FlowWithSource.builder().source(flowSource).id(flowId).build();
                     }
 
                     if (isAddition) {
@@ -192,12 +206,16 @@ public class Sync extends AbstractCloningTask implements RunnableTask<VoidOutput
             // prevent self deletion
             flowIdsImported.add(flowProps.get("id"));
 
-            flowRepository.findByNamespaceWithSource(tenantId, namespace).stream()
+            fetchFlowsFromKestra(kestraClient, tenantId, namespace).stream()
                 .filter(flow -> !flowIdsImported.contains(flow.getId()))
                 .forEach(flow ->
                 {
                     if (!dryRun) {
-                        flowRepository.delete(flow);
+                        try {
+                            kestraClient.flows().deleteFlow(flow.getNamespace(), flow.getId(), tenantId);
+                        } catch (ApiException e) {
+                            throw new KestraRuntimeException("Failed to delete flow " + flow.getId(), e);
+                        }
                     }
                     logDeletion(logger, "/_flows/" + flow.getId() + ".yml");
                 });
@@ -288,6 +306,94 @@ public class Sync extends AbstractCloningTask implements RunnableTask<VoidOutput
             }));
 
         return null;
+    }
+
+    private List<FlowWithSource> fetchFlowsFromKestra(KestraClient kestraClient, String tenantId, String namespace) {
+        try {
+            byte[] zippedFlows = kestraClient.flows().exportFlowsByQuery(
+                tenantId,
+                List.of(new QueryFilter().field(QueryFilterField.NAMESPACE).operation(QueryFilterOp.EQUALS).value(namespace))
+            );
+            List<FlowWithSource> flows = new ArrayList<>();
+            try (
+                var bais = new ByteArrayInputStream(zippedFlows);
+                var zis = new ZipInputStream(bais)
+            ) {
+                ZipEntry entry;
+                while ((entry = zis.getNextEntry()) != null) {
+                    if (!entry.getName().endsWith(".yml") && !entry.getName().endsWith(".yaml")) {
+                        continue;
+                    }
+                    var yaml = new String(zis.readAllBytes(), StandardCharsets.UTF_8);
+                    try {
+                        flows.add(FlowWithSource.of(YamlParser.parse(yaml, io.kestra.core.models.flows.Flow.class), yaml));
+                    } catch (Exception ignored) {
+                    }
+                }
+            }
+            return flows;
+        } catch (IOException | ApiException e) {
+            throw new KestraRuntimeException("Failed to export flows from Kestra for namespace " + namespace, e);
+        }
+    }
+
+    private FlowWithSource fetchSingleFlow(KestraClient kestraClient, String tenantId, String namespace, String flowId) {
+        try {
+            byte[] zippedFlows = kestraClient.flows().exportFlowsByQuery(
+                tenantId,
+                List.of(
+                    new QueryFilter().field(QueryFilterField.NAMESPACE).operation(QueryFilterOp.EQUALS).value(namespace),
+                    new QueryFilter().field(QueryFilterField.ID).operation(QueryFilterOp.EQUALS).value(flowId)
+                )
+            );
+            try (
+                var bais = new ByteArrayInputStream(zippedFlows);
+                var zis = new ZipInputStream(bais)
+            ) {
+                ZipEntry entry;
+                while ((entry = zis.getNextEntry()) != null) {
+                    if (!entry.getName().endsWith(".yml") && !entry.getName().endsWith(".yaml")) {
+                        continue;
+                    }
+                    var yaml = new String(zis.readAllBytes(), StandardCharsets.UTF_8);
+                    return FlowWithSource.of(YamlParser.parse(yaml, io.kestra.core.models.flows.Flow.class), yaml);
+                }
+            }
+            return null;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private File toNamedTempFile(String fileName, String yaml) {
+        try {
+            Path tmpPath = Files.createTempDirectory("kestra-import")
+                .resolve(fileName.endsWith(".yaml") ? fileName : fileName + ".yaml");
+            Files.createDirectories(tmpPath.getParent());
+            Files.writeString(tmpPath, yaml, StandardCharsets.UTF_8);
+            return tmpPath.toFile();
+        } catch (IOException e) {
+            throw new KestraRuntimeException("Failed to create named file for: " + fileName, e);
+        }
+    }
+
+    private KestraClient kestraClient(RunContext runContext) throws IllegalVariableEvaluationException {
+        String rKestraUrl;
+        try {
+            rKestraUrl = runContext.render("{{ kestra.url }}");
+        } catch (IllegalVariableEvaluationException e) {
+            rKestraUrl = "http://localhost:8080";
+        }
+        if (rKestraUrl == null || rKestraUrl.isBlank()) {
+            rKestraUrl = "http://localhost:8080";
+        }
+        String normalizedUrl = rKestraUrl.trim().replaceAll("/+$", "");
+        var builder = KestraClient.builder().url(normalizedUrl);
+        Optional<SDK.Auth> autoAuth = runContext.sdk().defaultAuthentication();
+        if (autoAuth.isPresent() && autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
+            return builder.basicAuth(autoAuth.get().username().get(), autoAuth.get().password().get()).build();
+        }
+        return builder.build();
     }
 
     private static void logDeletion(Logger logger, String path) {

--- a/src/main/java/io/kestra/plugin/git/Sync.java
+++ b/src/main/java/io/kestra/plugin/git/Sync.java
@@ -30,7 +30,6 @@ import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.models.tasks.VoidOutput;
 import io.kestra.core.runners.DefaultRunContext;
 import io.kestra.core.runners.RunContext;
-import io.kestra.core.runners.SDK;
 import io.kestra.core.serializers.YamlParser;
 import io.kestra.core.storages.StorageContext;
 import io.kestra.core.storages.StorageInterface;
@@ -375,25 +374,6 @@ public class Sync extends AbstractCloningTask implements RunnableTask<VoidOutput
         } catch (IOException e) {
             throw new KestraRuntimeException("Failed to create named file for: " + fileName, e);
         }
-    }
-
-    private KestraClient kestraClient(RunContext runContext) throws IllegalVariableEvaluationException {
-        String rKestraUrl;
-        try {
-            rKestraUrl = runContext.render("{{ kestra.url }}");
-        } catch (IllegalVariableEvaluationException e) {
-            rKestraUrl = "http://localhost:8080";
-        }
-        if (rKestraUrl == null || rKestraUrl.isBlank()) {
-            rKestraUrl = "http://localhost:8080";
-        }
-        String normalizedUrl = rKestraUrl.trim().replaceAll("/+$", "");
-        var builder = KestraClient.builder().url(normalizedUrl);
-        Optional<SDK.Auth> autoAuth = runContext.sdk().defaultAuthentication();
-        if (autoAuth.isPresent() && autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
-            return builder.basicAuth(autoAuth.get().username().get(), autoAuth.get().password().get()).build();
-        }
-        return builder.build();
     }
 
     private static void logDeletion(Logger logger, String path) {

--- a/src/main/java/io/kestra/plugin/git/SyncDashboards.java
+++ b/src/main/java/io/kestra/plugin/git/SyncDashboards.java
@@ -20,7 +20,6 @@ import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.dashboards.Dashboard;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
-import io.kestra.core.runners.SDK;
 import io.kestra.core.serializers.YamlParser;
 import io.kestra.sdk.KestraClient;
 import io.kestra.sdk.model.PagedResultsDashboard;
@@ -273,25 +272,6 @@ public class SyncDashboards extends AbstractSyncTask<Dashboard, SyncDashboards.O
             throw new KestraRuntimeException("Failed to fetch dashboard YAML for " + dashboardId + ": HTTP " + response.statusCode());
         }
         return response.body();
-    }
-
-    private KestraClient kestraClient(RunContext runContext) throws IllegalVariableEvaluationException {
-        String rKestraUrl;
-        try {
-            rKestraUrl = runContext.render("{{ kestra.url }}");
-        } catch (IllegalVariableEvaluationException e) {
-            rKestraUrl = "http://localhost:8080";
-        }
-        if (rKestraUrl == null || rKestraUrl.isBlank()) {
-            rKestraUrl = "http://localhost:8080";
-        }
-        String normalizedUrl = rKestraUrl.trim().replaceAll("/+$", "");
-        var builder = KestraClient.builder().url(normalizedUrl);
-        Optional<SDK.Auth> autoAuth = runContext.sdk().defaultAuthentication();
-        if (autoAuth.isPresent() && autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
-            return builder.basicAuth(autoAuth.get().username().get(), autoAuth.get().password().get()).build();
-        }
-        return builder.build();
     }
 
     @Override

--- a/src/main/java/io/kestra/plugin/git/SyncDashboards.java
+++ b/src/main/java/io/kestra/plugin/git/SyncDashboards.java
@@ -5,6 +5,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.time.Instant;
 import java.util.*;
 import java.util.regex.Pattern;
@@ -15,7 +16,6 @@ import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.exceptions.KestraRuntimeException;
 import io.kestra.core.http.HttpRequest;
 import io.kestra.core.http.client.HttpClient;
-import io.kestra.core.http.client.configurations.BasicAuthConfiguration;
 import io.kestra.core.http.client.configurations.HttpConfiguration;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
@@ -268,26 +268,22 @@ public class SyncDashboards extends AbstractSyncTask<Dashboard, SyncDashboards.O
             ? "/api/v1/dashboards/" + encodedId
             : "/api/v1/" + tenantId + "/dashboards/" + encodedId;
 
-        HttpConfiguration.HttpConfigurationBuilder configBuilder = HttpConfiguration.builder();
+        HttpRequest.HttpRequestBuilder requestBuilder = HttpRequest.builder()
+            .uri(URI.create(basePath + path))
+            .addHeader("Accept", "application/x-yaml");
         Optional<SDK.Auth> autoAuth = runContext.sdk().defaultAuthentication();
         if (autoAuth.isPresent() && autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
-            configBuilder.auth(BasicAuthConfiguration.builder()
-                .username(Property.ofValue(autoAuth.get().username().get()))
-                .password(Property.ofValue(autoAuth.get().password().get()))
-                .build());
+            String encoded = Base64.getEncoder().encodeToString(
+                (autoAuth.get().username().get() + ":" + autoAuth.get().password().get()).getBytes(StandardCharsets.UTF_8)
+            );
+            requestBuilder.addHeader("Authorization", "Basic " + encoded);
         }
 
         try (var httpClient = HttpClient.builder()
                 .runContext(runContext)
-                .configuration(configBuilder.build())
+                .configuration(HttpConfiguration.builder().build())
                 .build()) {
-            var response = httpClient.request(
-                HttpRequest.builder()
-                    .uri(URI.create(basePath + path))
-                    .addHeader("Accept", "application/x-yaml")
-                    .build(),
-                String.class
-            );
+            var response = httpClient.request(requestBuilder.build(), String.class);
             return response.getBody();
         }
     }

--- a/src/main/java/io/kestra/plugin/git/SyncDashboards.java
+++ b/src/main/java/io/kestra/plugin/git/SyncDashboards.java
@@ -5,26 +5,23 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-import java.util.Base64;
 import java.time.Instant;
 import java.util.*;
 import java.util.regex.Pattern;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import org.apache.commons.io.IOUtils;
 
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.exceptions.KestraRuntimeException;
-import io.kestra.core.http.HttpRequest;
-import io.kestra.core.http.client.HttpClient;
-import io.kestra.core.http.client.configurations.HttpConfiguration;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.dashboards.Dashboard;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
-import io.kestra.core.runners.SDK;
 import io.kestra.core.serializers.YamlParser;
 import io.kestra.sdk.KestraClient;
+import io.kestra.sdk.internal.ApiClient;
 import io.kestra.sdk.model.PagedResultsDashboard;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -262,34 +259,20 @@ public class SyncDashboards extends AbstractSyncTask<Dashboard, SyncDashboards.O
     }
 
     private String fetchDashboardSourceCode(KestraClient kestraClient, RunContext runContext, String tenantId, String dashboardId) throws Exception {
-        String basePath = kestraClient.dashboards().getApiClient().getBasePath();
+        ApiClient apiClient = kestraClient.dashboards().getApiClient();
         String encodedId = URLEncoder.encode(dashboardId, StandardCharsets.UTF_8);
         String path = tenantId == null
             ? "/api/v1/dashboards/" + encodedId
             : "/api/v1/" + tenantId + "/dashboards/" + encodedId;
 
-        HttpRequest.HttpRequestBuilder requestBuilder = HttpRequest.builder()
-            .uri(URI.create(basePath + path))
-            .addHeader("Accept", "application/x-yaml");
-        Optional<SDK.Auth> autoAuth = runContext.sdk().defaultAuthentication();
-        if (autoAuth.isPresent()) {
-            if (autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
-                String encoded = Base64.getEncoder().encodeToString(
-                    (autoAuth.get().username().get() + ":" + autoAuth.get().password().get()).getBytes(StandardCharsets.UTF_8)
-                );
-                requestBuilder.addHeader("Authorization", "Basic " + encoded);
-            } else if (autoAuth.get().apiToken().isPresent()) {
-                requestBuilder.addHeader("Authorization", "Bearer " + autoAuth.get().apiToken().get());
-            }
-        }
-
-        try (var httpClient = HttpClient.builder()
-                .runContext(runContext)
-                .configuration(HttpConfiguration.builder().build())
-                .build()) {
-            var response = httpClient.request(requestBuilder.build(), String.class);
-            return response.getBody();
-        }
+        byte[] yamlBytes = apiClient.invokeAPI(
+            path, "GET",
+            Collections.emptyList(), Collections.emptyList(), null,
+            null, Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
+            "application/x-yaml", null, new String[0],
+            new TypeReference<byte[]>() {}
+        );
+        return new String(yamlBytes, StandardCharsets.UTF_8);
     }
 
     @Override

--- a/src/main/java/io/kestra/plugin/git/SyncDashboards.java
+++ b/src/main/java/io/kestra/plugin/git/SyncDashboards.java
@@ -3,26 +3,27 @@ package io.kestra.plugin.git;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 import java.util.regex.Pattern;
 
 import org.apache.commons.io.IOUtils;
 
+import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.exceptions.KestraRuntimeException;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.dashboards.Dashboard;
 import io.kestra.core.models.property.Property;
-import io.kestra.core.repositories.ArrayListTotal;
-import io.kestra.core.repositories.DashboardRepositoryInterface;
-import io.micronaut.data.model.Pageable;
-import io.kestra.core.runners.DefaultRunContext;
 import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.SDK;
 import io.kestra.core.serializers.YamlParser;
+import io.kestra.sdk.KestraClient;
+import io.kestra.sdk.model.PagedResultsDashboard;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
@@ -97,10 +98,6 @@ public class SyncDashboards extends AbstractSyncTask<Dashboard, SyncDashboards.O
     @PluginProperty(group = "advanced")
     private Property<Boolean> delete = Property.ofValue(false);
 
-    private DashboardRepositoryInterface repository(RunContext runContext) {
-        return ((DefaultRunContext) runContext).services().additionalService(DashboardRepositoryInterface.class);
-    }
-
     @Override
     public Property<String> fetchedNamespace() {
         // Dashboards are not linked to namespaces
@@ -109,7 +106,11 @@ public class SyncDashboards extends AbstractSyncTask<Dashboard, SyncDashboards.O
 
     @Override
     protected void deleteResource(RunContext runContext, String renderedNamespace, Dashboard dashboard) {
-        repository(runContext).delete(runContext.flowInfo().tenantId(), dashboard.getId());
+        try {
+            kestraClient(runContext).dashboards().deleteDashboard(dashboard.getId(), runContext.flowInfo().tenantId());
+        } catch (Exception e) {
+            throw new KestraRuntimeException("Failed to delete dashboard " + dashboard.getId(), e);
+        }
     }
 
     @Override
@@ -127,23 +128,60 @@ public class SyncDashboards extends AbstractSyncTask<Dashboard, SyncDashboards.O
             return null;
         }
         String dashboardSource = IOUtils.toString(inputStream, StandardCharsets.UTF_8);
-        Dashboard dashboardWithTenant = YamlParser.parse(dashboardSource, Dashboard.class).toBuilder()
-            .tenantId(runContext.flowInfo().tenantId())
+        var tenantId = runContext.flowInfo().tenantId();
+        Dashboard parsedDashboard = YamlParser.parse(dashboardSource, Dashboard.class).toBuilder()
+            .tenantId(tenantId)
             .sourceCode(dashboardSource)
             .build();
-        DashboardRepositoryInterface dashboardRepositoryInterface = repository(runContext);
 
-        Optional<Dashboard> prevDashboard = dashboardRepositoryInterface.get(dashboardWithTenant.getTenantId(), dashboardWithTenant.getId());
+        // Look up the existing dashboard (if any) via the SDK search
+        Optional<Dashboard> prevDashboard = findExistingDashboard(runContext, tenantId, parsedDashboard.getId());
+
         if (dryRun) {
             return prevDashboard.map(previous ->
             {
-                if (previous.equals(dashboardWithTenant) && !previous.isDeleted()) {
+                // Compare source to detect changes
+                String prevSource = previous.getSourceCode() != null ? previous.getSourceCode() : "";
+                if (prevSource.replace("\r\n", "\n").strip().equals(dashboardSource.replace("\r\n", "\n").strip())) {
                     return previous;
                 }
-                return dashboardWithTenant.toBuilder().id(previous.getId()).created(previous.getCreated()).updated(Instant.now()).build();
-            }).orElseGet(() -> dashboardWithTenant.toBuilder().created(Instant.now()).updated(Instant.now()).build());
+                return parsedDashboard.toBuilder().id(previous.getId()).created(previous.getCreated()).updated(Instant.now()).build();
+            }).orElseGet(() -> parsedDashboard.toBuilder().created(Instant.now()).updated(Instant.now()).build());
         } else {
-            return dashboardRepositoryInterface.save(prevDashboard.orElse(null), dashboardWithTenant, dashboardSource);
+            try {
+                kestraClient(runContext).dashboards().createDashboard(tenantId, dashboardSource);
+            } catch (Exception e) {
+                throw new KestraRuntimeException("Failed to save dashboard " + parsedDashboard.getId(), e);
+            }
+            // Re-fetch to get the server-assigned updated timestamp
+            return findExistingDashboard(runContext, tenantId, parsedDashboard.getId())
+                .orElseGet(() -> parsedDashboard.toBuilder().updated(Instant.now()).build());
+        }
+    }
+
+    private Optional<Dashboard> findExistingDashboard(RunContext runContext, String tenantId, String dashboardId) {
+        try {
+            KestraClient kestraClient = kestraClient(runContext);
+            int page = 1;
+            int size = 200;
+            PagedResultsDashboard pagedResults;
+            do {
+                pagedResults = kestraClient.dashboards().searchDashboards(page, size, tenantId, null, null);
+                for (var sdkDash : pagedResults.getResults()) {
+                    if (dashboardId.equals(sdkDash.getId())) {
+                        // Fetch YAML source via raw HTTP call
+                        String sourceCode = fetchDashboardSourceCode(kestraClient, runContext, tenantId, dashboardId);
+                        return Optional.of(YamlParser.parse(sourceCode, Dashboard.class).toBuilder()
+                            .tenantId(tenantId)
+                            .sourceCode(sourceCode)
+                            .build());
+                    }
+                }
+                page++;
+            } while (pagedResults.getResults().size() == size);
+            return Optional.empty();
+        } catch (Exception e) {
+            return Optional.empty();
         }
     }
 
@@ -180,17 +218,80 @@ public class SyncDashboards extends AbstractSyncTask<Dashboard, SyncDashboards.O
 
     @Override
     protected List<Dashboard> fetchResources(RunContext runContext, String renderedNamespace) {
-        String tenantId = runContext.flowInfo().tenantId();
-        DashboardRepositoryInterface repo = repository(runContext);
-        List<Dashboard> all = new ArrayList<>();
-        final int pageSize = 100;
-        int page = 1;
-        ArrayListTotal<Dashboard> pageResult;
-        do {
-            pageResult = repo.list(Pageable.from(page++, pageSize), tenantId, null);
-            all.addAll(pageResult);
-        } while (all.size() < pageResult.getTotal());
-        return all;
+        try {
+            KestraClient kestraClient = kestraClient(runContext);
+            var tenantId = runContext.flowInfo().tenantId();
+            List<Dashboard> dashboards = new ArrayList<>();
+            int page = 1;
+            int size = 200;
+            PagedResultsDashboard pagedResults;
+            do {
+                pagedResults = kestraClient.dashboards().searchDashboards(page, size, tenantId, null, null);
+                for (var sdkDash : pagedResults.getResults()) {
+                    try {
+                        String sourceCode = fetchDashboardSourceCode(kestraClient, runContext, tenantId, sdkDash.getId());
+                        dashboards.add(YamlParser.parse(sourceCode, Dashboard.class).toBuilder()
+                            .tenantId(tenantId)
+                            .sourceCode(sourceCode)
+                            .build());
+                    } catch (Exception e) {
+                        runContext.logger().warn("Skipping dashboard {} — failed to fetch source: {}", sdkDash.getId(), e.getMessage());
+                    }
+                }
+                page++;
+            } while (pagedResults.getResults().size() == size);
+            return dashboards;
+        } catch (Exception e) {
+            throw new KestraRuntimeException("Failed to fetch dashboards from Kestra", e);
+        }
+    }
+
+    private String fetchDashboardSourceCode(KestraClient kestraClient, RunContext runContext, String tenantId, String dashboardId) throws Exception {
+        var apiClient = kestraClient.dashboards().getApiClient();
+        String path = tenantId == null
+            ? "/api/v1/dashboards/" + dashboardId
+            : "/api/v1/" + tenantId + "/dashboards/" + dashboardId;
+        String url = apiClient.getBaseURL() + path;
+
+        var requestBuilder = HttpRequest.newBuilder()
+            .uri(java.net.URI.create(url))
+            .header("Accept", "application/x-yaml")
+            .GET();
+
+        var autoAuth = runContext.sdk().defaultAuthentication();
+        if (autoAuth.isPresent() && autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
+            String encoded = Base64.getEncoder().encodeToString(
+                (autoAuth.get().username().get() + ":" + autoAuth.get().password().get()).getBytes(StandardCharsets.UTF_8));
+            requestBuilder.header("Authorization", "Basic " + encoded);
+        }
+
+        var response = HttpClient.newHttpClient().send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() == 401) {
+            throw new KestraRuntimeException("Authentication required to fetch dashboard YAML for " + dashboardId);
+        }
+        if (response.statusCode() != 200) {
+            throw new KestraRuntimeException("Failed to fetch dashboard YAML for " + dashboardId + ": HTTP " + response.statusCode());
+        }
+        return response.body();
+    }
+
+    private KestraClient kestraClient(RunContext runContext) throws IllegalVariableEvaluationException {
+        String rKestraUrl;
+        try {
+            rKestraUrl = runContext.render("{{ kestra.url }}");
+        } catch (IllegalVariableEvaluationException e) {
+            rKestraUrl = "http://localhost:8080";
+        }
+        if (rKestraUrl == null || rKestraUrl.isBlank()) {
+            rKestraUrl = "http://localhost:8080";
+        }
+        String normalizedUrl = rKestraUrl.trim().replaceAll("/+$", "");
+        var builder = KestraClient.builder().url(normalizedUrl);
+        Optional<SDK.Auth> autoAuth = runContext.sdk().defaultAuthentication();
+        if (autoAuth.isPresent() && autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
+            return builder.basicAuth(autoAuth.get().username().get(), autoAuth.get().password().get()).build();
+        }
+        return builder.build();
     }
 
     @Override

--- a/src/main/java/io/kestra/plugin/git/SyncDashboards.java
+++ b/src/main/java/io/kestra/plugin/git/SyncDashboards.java
@@ -170,9 +170,10 @@ public class SyncDashboards extends AbstractSyncTask<Dashboard, SyncDashboards.O
                     if (dashboardId.equals(sdkDash.getId())) {
                         // Fetch YAML source via raw HTTP call
                         String sourceCode = fetchDashboardSourceCode(kestraClient, runContext, tenantId, dashboardId);
-                        return Optional.of(YamlParser.parse(sourceCode, Dashboard.class).toBuilder()
+                        Dashboard parsed = YamlParser.parse(sourceCode, Dashboard.class);  // preserves getUpdated() from updated: injection
+                        return Optional.of(parsed.toBuilder()
                             .tenantId(tenantId)
-                            .sourceCode(sourceCode)
+                            .sourceCode(sourceCode.replaceAll("(?m)^updated:.*\\R?", ""))
                             .build());
                     }
                 }
@@ -196,7 +197,7 @@ public class SyncDashboards extends AbstractSyncTask<Dashboard, SyncDashboards.O
             syncState = SyncState.DELETED;
         } else if (dashboardBeforeUpdate == null) {
             syncState = SyncState.ADDED;
-        } else if (dashboardBeforeUpdate.getUpdated().equals(Objects.requireNonNull(dashboardAfterUpdate).getUpdated())) {
+        } else if (Objects.equals(dashboardBeforeUpdate.getUpdated(), Objects.requireNonNull(dashboardAfterUpdate).getUpdated())) {
             syncState = SyncState.UNCHANGED;
         } else {
             syncState = SyncState.UPDATED;
@@ -229,9 +230,10 @@ public class SyncDashboards extends AbstractSyncTask<Dashboard, SyncDashboards.O
                 for (var sdkDash : pagedResults.getResults()) {
                     try {
                         String sourceCode = fetchDashboardSourceCode(kestraClient, runContext, tenantId, sdkDash.getId());
-                        dashboards.add(YamlParser.parse(sourceCode, Dashboard.class).toBuilder()
+                        Dashboard parsed = YamlParser.parse(sourceCode, Dashboard.class);
+                        dashboards.add(parsed.toBuilder()
                             .tenantId(tenantId)
-                            .sourceCode(sourceCode)
+                            .sourceCode(sourceCode.replaceAll("(?m)^updated:.*\\R?", ""))
                             .build());
                     } catch (Exception e) {
                         runContext.logger().warn("Skipping dashboard {} — failed to fetch source: {}", sdkDash.getId(), e.getMessage());

--- a/src/main/java/io/kestra/plugin/git/SyncDashboards.java
+++ b/src/main/java/io/kestra/plugin/git/SyncDashboards.java
@@ -272,11 +272,15 @@ public class SyncDashboards extends AbstractSyncTask<Dashboard, SyncDashboards.O
             .uri(URI.create(basePath + path))
             .addHeader("Accept", "application/x-yaml");
         Optional<SDK.Auth> autoAuth = runContext.sdk().defaultAuthentication();
-        if (autoAuth.isPresent() && autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
-            String encoded = Base64.getEncoder().encodeToString(
-                (autoAuth.get().username().get() + ":" + autoAuth.get().password().get()).getBytes(StandardCharsets.UTF_8)
-            );
-            requestBuilder.addHeader("Authorization", "Basic " + encoded);
+        if (autoAuth.isPresent()) {
+            if (autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
+                String encoded = Base64.getEncoder().encodeToString(
+                    (autoAuth.get().username().get() + ":" + autoAuth.get().password().get()).getBytes(StandardCharsets.UTF_8)
+                );
+                requestBuilder.addHeader("Authorization", "Basic " + encoded);
+            } else if (autoAuth.get().apiToken().isPresent()) {
+                requestBuilder.addHeader("Authorization", "Bearer " + autoAuth.get().apiToken().get());
+            }
         }
 
         try (var httpClient = HttpClient.builder()

--- a/src/main/java/io/kestra/plugin/git/SyncDashboards.java
+++ b/src/main/java/io/kestra/plugin/git/SyncDashboards.java
@@ -3,9 +3,7 @@ package io.kestra.plugin.git;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
+import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.*;
@@ -15,11 +13,16 @@ import org.apache.commons.io.IOUtils;
 
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.exceptions.KestraRuntimeException;
+import io.kestra.core.http.HttpRequest;
+import io.kestra.core.http.client.HttpClient;
+import io.kestra.core.http.client.configurations.BasicAuthConfiguration;
+import io.kestra.core.http.client.configurations.HttpConfiguration;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.dashboards.Dashboard;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.SDK;
 import io.kestra.core.serializers.YamlParser;
 import io.kestra.sdk.KestraClient;
 import io.kestra.sdk.model.PagedResultsDashboard;
@@ -259,32 +262,34 @@ public class SyncDashboards extends AbstractSyncTask<Dashboard, SyncDashboards.O
     }
 
     private String fetchDashboardSourceCode(KestraClient kestraClient, RunContext runContext, String tenantId, String dashboardId) throws Exception {
-        var apiClient = kestraClient.dashboards().getApiClient();
+        String basePath = kestraClient.dashboards().getApiClient().getBasePath();
+        String encodedId = URLEncoder.encode(dashboardId, StandardCharsets.UTF_8);
         String path = tenantId == null
-            ? "/api/v1/dashboards/" + dashboardId
-            : "/api/v1/" + tenantId + "/dashboards/" + dashboardId;
-        String url = apiClient.getBaseURL() + path;
+            ? "/api/v1/dashboards/" + encodedId
+            : "/api/v1/" + tenantId + "/dashboards/" + encodedId;
 
-        var requestBuilder = HttpRequest.newBuilder()
-            .uri(java.net.URI.create(url))
-            .header("Accept", "application/x-yaml")
-            .GET();
-
-        var autoAuth = runContext.sdk().defaultAuthentication();
+        HttpConfiguration.HttpConfigurationBuilder configBuilder = HttpConfiguration.builder();
+        Optional<SDK.Auth> autoAuth = runContext.sdk().defaultAuthentication();
         if (autoAuth.isPresent() && autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
-            String encoded = Base64.getEncoder().encodeToString(
-                (autoAuth.get().username().get() + ":" + autoAuth.get().password().get()).getBytes(StandardCharsets.UTF_8));
-            requestBuilder.header("Authorization", "Basic " + encoded);
+            configBuilder.auth(BasicAuthConfiguration.builder()
+                .username(Property.ofValue(autoAuth.get().username().get()))
+                .password(Property.ofValue(autoAuth.get().password().get()))
+                .build());
         }
 
-        var response = HttpClient.newHttpClient().send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString());
-        if (response.statusCode() == 401) {
-            throw new KestraRuntimeException("Authentication required to fetch dashboard YAML for " + dashboardId);
+        try (var httpClient = HttpClient.builder()
+                .runContext(runContext)
+                .configuration(configBuilder.build())
+                .build()) {
+            var response = httpClient.request(
+                HttpRequest.builder()
+                    .uri(URI.create(basePath + path))
+                    .addHeader("Accept", "application/x-yaml")
+                    .build(),
+                String.class
+            );
+            return response.getBody();
         }
-        if (response.statusCode() != 200) {
-            throw new KestraRuntimeException("Failed to fetch dashboard YAML for " + dashboardId + ": HTTP " + response.statusCode());
-        }
-        return response.body();
     }
 
     @Override

--- a/src/main/java/io/kestra/plugin/git/SyncDashboards.java
+++ b/src/main/java/io/kestra/plugin/git/SyncDashboards.java
@@ -147,6 +147,17 @@ public class SyncDashboards extends AbstractSyncTask<Dashboard, SyncDashboards.O
                 return parsedDashboard.toBuilder().id(previous.getId()).created(previous.getCreated()).updated(Instant.now()).build();
             }).orElseGet(() -> parsedDashboard.toBuilder().created(Instant.now()).updated(Instant.now()).build());
         } else {
+            // Skip createDashboard if content is unchanged to preserve the updated timestamp
+            // (UNCHANGED detection in wrapper() compares before/after updated timestamps)
+            boolean contentChanged = prevDashboard.map(previous -> {
+                String prevSource = previous.getSourceCode() != null ? previous.getSourceCode() : "";
+                return !prevSource.replace("\r\n", "\n").strip().equals(dashboardSource.replace("\r\n", "\n").strip());
+            }).orElse(true);
+
+            if (!contentChanged) {
+                return prevDashboard.get();
+            }
+
             try {
                 kestraClient(runContext).dashboards().createDashboard(tenantId, dashboardSource);
             } catch (Exception e) {

--- a/src/main/java/io/kestra/plugin/git/SyncDashboards.java
+++ b/src/main/java/io/kestra/plugin/git/SyncDashboards.java
@@ -265,14 +265,14 @@ public class SyncDashboards extends AbstractSyncTask<Dashboard, SyncDashboards.O
             ? "/api/v1/dashboards/" + encodedId
             : "/api/v1/" + tenantId + "/dashboards/" + encodedId;
 
-        byte[] yamlBytes = apiClient.invokeAPI(
+        Map<String, Object> response = apiClient.invokeAPI(
             path, "GET",
             Collections.emptyList(), Collections.emptyList(), null,
             null, Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
-            "application/x-yaml", null, new String[0],
-            new TypeReference<byte[]>() {}
+            "application/json", null, new String[0],
+            new TypeReference<Map<String, Object>>() {}
         );
-        return new String(yamlBytes, StandardCharsets.UTF_8);
+        return (String) response.get("sourceCode");
     }
 
     @Override

--- a/src/main/java/io/kestra/plugin/git/SyncFlow.java
+++ b/src/main/java/io/kestra/plugin/git/SyncFlow.java
@@ -64,7 +64,7 @@ import io.kestra.core.models.annotations.PluginProperty;
 public class SyncFlow extends AbstractKestraTask implements RunnableTask<SyncFlow.Output> {
 
     public static final Pattern NAMESPACE_FINDER_PATTERN = Pattern.compile("(?m)^\\s*namespace:\\s*(.*)$");
-    private static final Pattern FLOW_ID_FINDER_PATTERN = Pattern.compile("(?m)^\\s*id:\\s*(.*)$");
+    private static final Pattern FLOW_ID_FINDER_PATTERN = Pattern.compile("(?m)^id:\\s*(.*)$");
 
     @Schema(
         title = "Branch to clone",
@@ -171,7 +171,7 @@ public class SyncFlow extends AbstractKestraTask implements RunnableTask<SyncFlo
                 .revision(projectedRevision);
         } else {
             // Import the flow
-            var tempFile = toNamedTempFile(flowId + ".yaml", flowSource);
+            var tempFile = toNamedTempFile(flowId + ".yaml", flowSource.stripTrailing());
             kestraClient.flows().importFlows(true, tenantId, tempFile);
 
             // Fetch the saved flow to populate the output

--- a/src/main/java/io/kestra/plugin/git/SyncFlow.java
+++ b/src/main/java/io/kestra/plugin/git/SyncFlow.java
@@ -12,13 +12,13 @@ import org.eclipse.jgit.api.Git;
 
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
-import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
-import io.kestra.core.runners.DefaultRunContext;
 import io.kestra.core.runners.RunContext;
-import io.kestra.core.services.FlowService;
 import io.kestra.plugin.git.services.GitService;
+import io.kestra.sdk.KestraClient;
+import io.kestra.sdk.internal.ApiException;
+import io.kestra.sdk.model.FlowWithSource;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -53,13 +53,18 @@ import io.kestra.core.models.annotations.PluginProperty;
                     password: "{{ secret('GITHUB_ACCESS_TOKEN') }}"
                     targetNamespace: dev.marketing # required
                     flowPath: "flows/marketing/flow.yml" # required
+                    kestraUrl: "http://localhost:8080"
+                    auth:
+                      username: "{{ secret('KESTRA_USERNAME') }}"
+                      password: "{{ secret('KESTRA_PASSWORD') }}"
                 """
         )
     }
 )
-public class SyncFlow extends AbstractGitTask implements RunnableTask<SyncFlow.Output> {
+public class SyncFlow extends AbstractKestraTask implements RunnableTask<SyncFlow.Output> {
 
     public static final Pattern NAMESPACE_FINDER_PATTERN = Pattern.compile("(?m)^\\s*namespace:\\s*(.*)$");
+    private static final Pattern FLOW_ID_FINDER_PATTERN = Pattern.compile("(?m)^\\s*id:\\s*(.*)$");
 
     @Schema(
         title = "Branch to clone",
@@ -107,7 +112,6 @@ public class SyncFlow extends AbstractGitTask implements RunnableTask<SyncFlow.O
         configureEnvironmentWithSsl(runContext);
 
         GitService gitService = new GitService(this);
-        FlowService flowService = ((DefaultRunContext) runContext).services().additionalService(FlowService.class);
 
         Git git = gitService.cloneBranch(runContext, runContext.render(this.getBranch()).as(String.class).orElse(null), Property.ofValue(Boolean.FALSE));
         Path cloneDir = git.getRepository().getWorkTree().toPath();
@@ -119,24 +123,82 @@ public class SyncFlow extends AbstractGitTask implements RunnableTask<SyncFlow.O
             throw new java.io.FileNotFoundException("Flow file not found at path: " + renderedFlowPath);
         }
 
+        // Build the client only after confirming the file exists, to keep failures fast and clear
+        KestraClient kestraClient = kestraClient(runContext);
+
         String renderedNamespace = runContext.render(this.targetNamespace).as(String.class).orElseThrow();
         String flowSource;
         try (InputStream is = Files.newInputStream(flowFilePath)) {
             flowSource = IOUtils.toString(is, StandardCharsets.UTF_8);
         }
 
-        Matcher matcher = NAMESPACE_FINDER_PATTERN.matcher(flowSource);
-        flowSource = matcher.replaceFirst("namespace: " + renderedNamespace);
+        // Rewrite the namespace to the target namespace
+        Matcher namespaceMatcher = NAMESPACE_FINDER_PATTERN.matcher(flowSource);
+        flowSource = namespaceMatcher.replaceFirst("namespace: " + renderedNamespace);
 
-        Flow flow = flowService.importFlow(runContext.flowInfo().tenantId(), flowSource.stripTrailing(), runContext.render(this.dryRun).as(Boolean.class).orElse(Boolean.FALSE));
+        // Parse the flow id from the (potentially rewritten) YAML
+        Matcher idMatcher = FLOW_ID_FINDER_PATTERN.matcher(flowSource);
+        if (!idMatcher.find()) {
+            throw new IllegalStateException("Cannot parse flow id from YAML at path: " + renderedFlowPath);
+        }
+        String flowId = idMatcher.group(1).trim();
+
+        String tenantId = runContext.flowInfo().tenantId();
+        boolean rDryRun = runContext.render(this.dryRun).as(Boolean.class).orElse(Boolean.FALSE);
+
+        FlowWithSource result;
+
+        if (rDryRun) {
+            // Validate without importing; compute projected revision
+            var violations = kestraClient.flows().validateFlows(tenantId, flowSource);
+            if (!violations.isEmpty() && violations.getFirst().getConstraints() != null) {
+                throw new IllegalStateException("Flow validation failed: " + violations.getFirst().getConstraints());
+            }
+
+            // Projected revision: existing + 1, or 1 for a new flow
+            int projectedRevision;
+            try {
+                FlowWithSource existing = kestraClient.flows().flow(renderedNamespace, flowId, false, false, tenantId, null);
+                projectedRevision = existing.getRevision() != null ? existing.getRevision() + 1 : 1;
+            } catch (ApiException e) {
+                // Flow does not exist yet
+                projectedRevision = 1;
+            }
+
+            result = new FlowWithSource()
+                .id(flowId)
+                .namespace(renderedNamespace)
+                .revision(projectedRevision);
+        } else {
+            // Import the flow
+            var tempFile = toNamedTempFile(flowId + ".yaml", flowSource);
+            kestraClient.flows().importFlows(true, tenantId, tempFile);
+
+            // Fetch the saved flow to populate the output
+            result = kestraClient.flows().flow(renderedNamespace, flowId, false, false, tenantId, null);
+        }
 
         git.close();
 
         return Output.builder()
-            .flowId(flow.getId())
-            .namespace(flow.getNamespace())
-            .revision(flow.getRevision())
+            .flowId(result.getId())
+            .namespace(result.getNamespace())
+            .revision(result.getRevision())
             .build();
+    }
+
+    private java.io.File toNamedTempFile(String fileName, String yaml) {
+        try {
+            Path tmpPath = Files.createTempDirectory("kestra-import")
+                .resolve(fileName.endsWith(".yaml") ? fileName : fileName + ".yaml");
+
+            Files.createDirectories(tmpPath.getParent());
+            Files.writeString(tmpPath, yaml, StandardCharsets.UTF_8);
+
+            return tmpPath.toFile();
+        } catch (java.io.IOException e) {
+            throw new io.kestra.core.exceptions.KestraRuntimeException("Failed to create named file for: " + fileName, e);
+        }
     }
 
     @SuperBuilder

--- a/src/main/java/io/kestra/plugin/git/SyncFlows.java
+++ b/src/main/java/io/kestra/plugin/git/SyncFlows.java
@@ -1,28 +1,38 @@
 package io.kestra.plugin.git;
 
+import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
-import java.util.List;
-import java.util.Objects;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
 
 import org.apache.commons.io.IOUtils;
 
 import io.kestra.core.exceptions.FlowProcessingException;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.exceptions.KestraRuntimeException;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.flows.Flow;
-import io.kestra.core.models.flows.FlowSource;
 import io.kestra.core.models.flows.FlowWithException;
 import io.kestra.core.models.flows.FlowWithSource;
 import io.kestra.core.models.property.Property;
-import io.kestra.core.runners.DefaultRunContext;
 import io.kestra.core.runners.RunContext;
-import io.kestra.core.services.FlowService;
+import io.kestra.core.runners.SDK;
+import io.kestra.core.serializers.YamlParser;
+import io.kestra.sdk.KestraClient;
+import io.kestra.sdk.internal.ApiException;
+import io.kestra.sdk.model.QueryFilter;
+import io.kestra.sdk.model.QueryFilterField;
+import io.kestra.sdk.model.QueryFilterOp;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -158,16 +168,6 @@ public class SyncFlows extends AbstractSyncTask<Flow, SyncFlows.Output> {
     @PluginProperty(group = "advanced")
     private Property<Boolean> ignoreInvalidFlows = Property.ofValue(false);
 
-    @Getter(AccessLevel.NONE)
-    private FlowService flowService;
-
-    private FlowService flowService(RunContext runContext) {
-        if (flowService == null) {
-            flowService = ((DefaultRunContext) runContext).services().additionalService(FlowService.class);
-        }
-        return flowService;
-    }
-
     @Override
     public Property<String> fetchedNamespace() {
         return this.targetNamespace;
@@ -175,7 +175,11 @@ public class SyncFlows extends AbstractSyncTask<Flow, SyncFlows.Output> {
 
     @Override
     protected void deleteResource(RunContext runContext, String renderedNamespace, Flow flow) {
-        flowService(runContext).delete(FlowWithSource.of(flow, ""));
+        try {
+            kestraClient(runContext).flows().deleteFlow(flow.getNamespace(), flow.getId(), runContext.flowInfo().tenantId());
+        } catch (ApiException | IllegalVariableEvaluationException e) {
+            throw new KestraRuntimeException("Failed to delete flow " + flow.getId(), e);
+        }
     }
 
     @Override
@@ -187,24 +191,40 @@ public class SyncFlows extends AbstractSyncTask<Flow, SyncFlows.Output> {
 
         String flowSource = SyncFlows.replaceNamespace(renderedNamespace, uri, inputStream);
 
-        var flowValidated = flowService.validate(runContext.flowInfo().tenantId(), List.of(new FlowSource(null, flowSource))).getFirst();
+        var flowValidated = kestraClient(runContext).flows().validateFlows(runContext.flowInfo().tenantId(), flowSource).getFirst();
 
         if (flowValidated.getConstraints() != null) {
             var ref = uri.getPath();
-
             if (ref.startsWith("/")) {
                 ref = ref.substring(1);
             }
-
             if (runContext.render(this.ignoreInvalidFlows).as(Boolean.class).orElse(false)) {
                 runContext.logger().warn("Invalid flow imported from Git ({}): {}", ref, flowValidated.getConstraints());
                 return null;
             }
-
             throw new FlowProcessingException("Invalid flow imported from Git (" + ref + "): " + flowValidated.getConstraints());
         }
 
-        return flowService(runContext).importFlow(runContext.flowInfo().tenantId(), flowSource, true);
+        // Simulate: parse the source and determine if it differs from the current Kestra state
+        var parsedFromSource = YamlParser.parse(flowSource, Flow.class);
+        var tenantId = runContext.flowInfo().tenantId();
+        var currentFlow = fetchSingleFlow(kestraClient(runContext), tenantId, parsedFromSource.getNamespace(), parsedFromSource.getId());
+
+        if (currentFlow == null) {
+            // New flow — revision will be 1 after import
+            return parsedFromSource.toBuilder().revision(1).build();
+        }
+
+        // Compare normalised source to detect changes
+        var normalised = flowSource.replace("\r\n", "\n").strip();
+        var currentNormalised = currentFlow.getSource().replace("\r\n", "\n").strip();
+        if (normalised.equals(currentNormalised)) {
+            // Unchanged — return the current flow so wrapper detects UNCHANGED
+            return currentFlow;
+        }
+
+        // Changed — simulate next revision
+        return parsedFromSource.toBuilder().revision(currentFlow.getRevision() + 1).build();
     }
 
     @Override
@@ -228,25 +248,30 @@ public class SyncFlows extends AbstractSyncTask<Flow, SyncFlows.Output> {
         }
 
         String flowSource = SyncFlows.replaceNamespace(renderedNamespace, uri, inputStream);
+        var kestraClient = kestraClient(runContext);
+        var tenantId = runContext.flowInfo().tenantId();
 
-        var flowValidated = flowService.validate(runContext.flowInfo().tenantId(), List.of(new FlowSource(null, flowSource))).getFirst();
+        var flowValidated = kestraClient.flows().validateFlows(tenantId, flowSource).getFirst();
 
         if (flowValidated.getConstraints() != null) {
             var ref = uri.getPath();
-
             if (ref.startsWith("/")) {
                 ref = ref.substring(1);
             }
-
             if (runContext.render(this.ignoreInvalidFlows).as(Boolean.class).orElse(false)) {
                 runContext.logger().warn("Invalid flow imported from Git ({}): {}", ref, flowValidated.getConstraints());
                 return null;
             }
-
             throw new FlowProcessingException("Invalid flow imported from Git (" + ref + "): " + flowValidated.getConstraints());
         }
 
-        return flowService(runContext).importFlow(runContext.flowInfo().tenantId(), flowSource, false);
+        var parsedId = YamlParser.parse(flowSource, Flow.class).getId();
+        kestraClient.flows().importFlows(true, tenantId, toNamedTempFile(parsedId + ".yaml", flowSource.stripTrailing()));
+
+        // Re-fetch from Kestra to get the updated revision
+        var parsedNamespace = YamlParser.parse(flowSource, Flow.class).getNamespace();
+        var updated = fetchSingleFlow(kestraClient, tenantId, parsedNamespace, parsedId);
+        return updated != null ? updated : YamlParser.parse(flowSource, Flow.class);
     }
 
     private static String replaceNamespace(String renderedNamespace, URI uri, InputStream inputStream) throws IOException {
@@ -295,12 +320,9 @@ public class SyncFlows extends AbstractSyncTask<Flow, SyncFlows.Output> {
 
     @Override
     protected List<Flow> fetchResources(RunContext runContext, String renderedNamespace) throws IllegalVariableEvaluationException {
-        List<Flow> flows;
-        if (runContext.render(this.includeChildNamespaces).as(Boolean.class).orElseThrow()) {
-            flows = flowService(runContext).findByNamespacePrefix(runContext.flowInfo().tenantId(), renderedNamespace);
-        } else {
-            flows = flowService(runContext).findByNamespace(runContext.flowInfo().tenantId(), renderedNamespace);
-        }
+        boolean includeChildren = runContext.render(this.includeChildNamespaces).as(Boolean.class).orElseThrow();
+        var op = includeChildren ? QueryFilterOp.STARTS_WITH : QueryFilterOp.EQUALS;
+        List<Flow> flows = fetchFlowsFromKestra(kestraClient(runContext), runContext, runContext.flowInfo().tenantId(), renderedNamespace, op);
         if (runContext.render(this.ignoreInvalidFlows).as(Boolean.class).orElse(false)) {
             flows = flows.stream()
                 .filter(flow ->
@@ -314,6 +336,98 @@ public class SyncFlows extends AbstractSyncTask<Flow, SyncFlows.Output> {
                 .toList();
         }
         return flows;
+    }
+
+    private List<Flow> fetchFlowsFromKestra(KestraClient kestraClient, RunContext runContext, String tenantId, String namespace, QueryFilterOp op) {
+        try {
+            byte[] zippedFlows = kestraClient.flows().exportFlowsByQuery(
+                tenantId,
+                List.of(new QueryFilter().field(QueryFilterField.NAMESPACE).operation(op).value(namespace))
+            );
+
+            List<Flow> flows = new ArrayList<>();
+            try (
+                var bais = new ByteArrayInputStream(zippedFlows);
+                var zis = new ZipInputStream(bais)
+            ) {
+                ZipEntry entry;
+                while ((entry = zis.getNextEntry()) != null) {
+                    if (!entry.getName().endsWith(".yml") && !entry.getName().endsWith(".yaml")) {
+                        continue;
+                    }
+                    var yaml = new String(zis.readAllBytes(), StandardCharsets.UTF_8);
+                    try {
+                        flows.add(FlowWithSource.of(YamlParser.parse(yaml, Flow.class), yaml));
+                    } catch (Exception e) {
+                        runContext.logger().warn("Skipping invalid flow from entry {}: {}", entry.getName(), e.getMessage());
+                    }
+                }
+            }
+            return flows;
+        } catch (IOException e) {
+            throw new KestraRuntimeException("Failed to export flows from Kestra for namespace " + namespace, e);
+        } catch (ApiException e) {
+            throw new KestraRuntimeException("Failed to export flows from Kestra for namespace " + namespace, e);
+        }
+    }
+
+    private FlowWithSource fetchSingleFlow(KestraClient kestraClient, String tenantId, String namespace, String flowId) {
+        try {
+            byte[] zippedFlows = kestraClient.flows().exportFlowsByQuery(
+                tenantId,
+                List.of(
+                    new QueryFilter().field(QueryFilterField.NAMESPACE).operation(QueryFilterOp.EQUALS).value(namespace),
+                    new QueryFilter().field(QueryFilterField.ID).operation(QueryFilterOp.EQUALS).value(flowId)
+                )
+            );
+            try (
+                var bais = new ByteArrayInputStream(zippedFlows);
+                var zis = new ZipInputStream(bais)
+            ) {
+                ZipEntry entry;
+                while ((entry = zis.getNextEntry()) != null) {
+                    if (!entry.getName().endsWith(".yml") && !entry.getName().endsWith(".yaml")) {
+                        continue;
+                    }
+                    var yaml = new String(zis.readAllBytes(), StandardCharsets.UTF_8);
+                    return FlowWithSource.of(YamlParser.parse(yaml, Flow.class), yaml);
+                }
+            }
+            return null;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private File toNamedTempFile(String fileName, String yaml) {
+        try {
+            Path tmpPath = Files.createTempDirectory("kestra-import")
+                .resolve(fileName.endsWith(".yaml") ? fileName : fileName + ".yaml");
+            Files.createDirectories(tmpPath.getParent());
+            Files.writeString(tmpPath, yaml, StandardCharsets.UTF_8);
+            return tmpPath.toFile();
+        } catch (IOException e) {
+            throw new KestraRuntimeException("Failed to create named file for: " + fileName, e);
+        }
+    }
+
+    private KestraClient kestraClient(RunContext runContext) throws IllegalVariableEvaluationException {
+        String rKestraUrl;
+        try {
+            rKestraUrl = runContext.render("{{ kestra.url }}");
+        } catch (IllegalVariableEvaluationException e) {
+            rKestraUrl = "http://localhost:8080";
+        }
+        if (rKestraUrl == null || rKestraUrl.isBlank()) {
+            rKestraUrl = "http://localhost:8080";
+        }
+        String normalizedUrl = rKestraUrl.trim().replaceAll("/+$", "");
+        var builder = KestraClient.builder().url(normalizedUrl);
+        Optional<SDK.Auth> autoAuth = runContext.sdk().defaultAuthentication();
+        if (autoAuth.isPresent() && autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
+            return builder.basicAuth(autoAuth.get().username().get(), autoAuth.get().password().get()).build();
+        }
+        return builder.build();
     }
 
     @Override

--- a/src/main/java/io/kestra/plugin/git/SyncFlows.java
+++ b/src/main/java/io/kestra/plugin/git/SyncFlows.java
@@ -229,9 +229,12 @@ public class SyncFlows extends AbstractSyncTask<Flow, SyncFlows.Output> {
     @Override
     protected boolean mustKeep(RunContext runContext, Flow instanceResource) {
         RunContext.FlowInfo flowInfo = runContext.flowInfo();
+        String resourceTenantId = instanceResource.getTenantId();
+        // Flows parsed from ZIP export YAML never carry a tenantId field — treat null as matching
+        boolean tenantMatches = resourceTenantId == null || Objects.equals(flowInfo.tenantId(), resourceTenantId);
         return flowInfo.id().equals(instanceResource.getId()) &&
             flowInfo.namespace().equals(instanceResource.getNamespace()) &&
-            Objects.equals(flowInfo.tenantId(), instanceResource.getTenantId());
+            tenantMatches;
     }
 
     @Override

--- a/src/main/java/io/kestra/plugin/git/SyncFlows.java
+++ b/src/main/java/io/kestra/plugin/git/SyncFlows.java
@@ -215,8 +215,10 @@ public class SyncFlows extends AbstractSyncTask<Flow, SyncFlows.Output> {
         }
 
         // Compare normalised source to detect changes
+        // Strip revision: from the exported source — the Kestra ZIP export injects it but git sources never have it
         var normalised = flowSource.replace("\r\n", "\n").strip();
-        var currentNormalised = currentFlow.getSource().replace("\r\n", "\n").strip();
+        var currentSourceWithoutRevision = currentFlow.getSource().replaceAll("(?m)^revision:\\s*\\d+\\n?", "");
+        var currentNormalised = currentSourceWithoutRevision.replace("\r\n", "\n").strip();
         if (normalised.equals(currentNormalised)) {
             // Unchanged — return the current flow so wrapper detects UNCHANGED
             return currentFlow;

--- a/src/main/java/io/kestra/plugin/git/SyncFlows.java
+++ b/src/main/java/io/kestra/plugin/git/SyncFlows.java
@@ -26,7 +26,6 @@ import io.kestra.core.models.flows.FlowWithException;
 import io.kestra.core.models.flows.FlowWithSource;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
-import io.kestra.core.runners.SDK;
 import io.kestra.core.serializers.YamlParser;
 import io.kestra.sdk.KestraClient;
 import io.kestra.sdk.internal.ApiException;
@@ -409,25 +408,6 @@ public class SyncFlows extends AbstractSyncTask<Flow, SyncFlows.Output> {
         } catch (IOException e) {
             throw new KestraRuntimeException("Failed to create named file for: " + fileName, e);
         }
-    }
-
-    private KestraClient kestraClient(RunContext runContext) throws IllegalVariableEvaluationException {
-        String rKestraUrl;
-        try {
-            rKestraUrl = runContext.render("{{ kestra.url }}");
-        } catch (IllegalVariableEvaluationException e) {
-            rKestraUrl = "http://localhost:8080";
-        }
-        if (rKestraUrl == null || rKestraUrl.isBlank()) {
-            rKestraUrl = "http://localhost:8080";
-        }
-        String normalizedUrl = rKestraUrl.trim().replaceAll("/+$", "");
-        var builder = KestraClient.builder().url(normalizedUrl);
-        Optional<SDK.Auth> autoAuth = runContext.sdk().defaultAuthentication();
-        if (autoAuth.isPresent() && autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
-            return builder.basicAuth(autoAuth.get().username().get(), autoAuth.get().password().get()).build();
-        }
-        return builder.build();
     }
 
     @Override

--- a/src/main/java/io/kestra/plugin/git/TenantSync.java
+++ b/src/main/java/io/kestra/plugin/git/TenantSync.java
@@ -1024,14 +1024,14 @@ public class TenantSync extends AbstractKestraTask implements RunnableTask<Tenan
             ? "/api/v1/dashboards/" + encodedId
             : "/api/v1/" + tenantId + "/dashboards/" + encodedId;
 
-        byte[] yamlBytes = apiClient.invokeAPI(
+        Map<String, Object> response = apiClient.invokeAPI(
             path, "GET",
             Collections.emptyList(), Collections.emptyList(), null,
             null, Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
-            "application/x-yaml", null, new String[0],
-            new TypeReference<byte[]>() {}
+            "application/json", null, new String[0],
+            new TypeReference<Map<String, Object>>() {}
         );
-        return new String(yamlBytes, StandardCharsets.UTF_8);
+        return (String) response.get("sourceCode");
     }
 
     private File toNamedTempFile(String fileName, String yaml) {

--- a/src/main/java/io/kestra/plugin/git/TenantSync.java
+++ b/src/main/java/io/kestra/plugin/git/TenantSync.java
@@ -2,9 +2,7 @@ package io.kestra.plugin.git;
 
 import java.io.*;
 import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
+import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileVisitOption;
 import java.nio.file.Files;
@@ -26,6 +24,11 @@ import org.eclipse.jgit.transport.RemoteRefUpdate;
 import io.kestra.core.exceptions.FlowProcessingException;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.exceptions.KestraRuntimeException;
+import io.kestra.core.http.HttpRequest;
+import io.kestra.core.http.client.HttpClient;
+import io.kestra.core.http.client.configurations.BasicAuthConfiguration;
+import io.kestra.core.http.client.configurations.HttpConfiguration;
+import io.kestra.core.runners.SDK;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.flows.FlowWithSource;
@@ -1018,41 +1021,46 @@ public class TenantSync extends AbstractKestraTask implements RunnableTask<Tenan
     }
 
     private String fetchDashboardSourceCode(KestraClient kestraClient, RunContext runContext, String tenantId, String dashboardId) throws Exception {
-        var apiClient = kestraClient.dashboards().getApiClient();
+        String basePath = kestraClient.dashboards().getApiClient().getBasePath();
+        String encodedId = URLEncoder.encode(dashboardId, StandardCharsets.UTF_8);
         String path = tenantId == null
-            ? "/api/v1/dashboards/" + dashboardId
-            : "/api/v1/" + tenantId + "/dashboards/" + dashboardId;
-        String url = apiClient.getBaseURL() + path;
+            ? "/api/v1/dashboards/" + encodedId
+            : "/api/v1/" + tenantId + "/dashboards/" + encodedId;
 
-        var requestBuilder = HttpRequest.newBuilder()
-            .uri(URI.create(url))
-            .header("Accept", "application/x-yaml")
-            .GET();
-
-        // Apply authentication: explicit auth property first, then SDK default
-        var authProperty = getAuth();
-        if (authProperty != null) {
-            var maybeUsername = runContext.render(authProperty.getUsername()).as(String.class);
-            var maybePassword = runContext.render(authProperty.getPassword()).as(String.class);
+        HttpConfiguration.HttpConfigurationBuilder configBuilder = HttpConfiguration.builder();
+        AbstractKestraTask.Auth auth = getAuth();
+        if (auth != null) {
+            Optional<String> maybeUsername = runContext.render(auth.getUsername()).as(String.class);
+            Optional<String> maybePassword = runContext.render(auth.getPassword()).as(String.class);
             if (maybeUsername.isPresent() && maybePassword.isPresent()) {
-                String encoded = Base64.getEncoder().encodeToString(
-                    (maybeUsername.get() + ":" + maybePassword.get()).getBytes(StandardCharsets.UTF_8));
-                requestBuilder.header("Authorization", "Basic " + encoded);
+                configBuilder.auth(BasicAuthConfiguration.builder()
+                    .username(Property.ofValue(maybeUsername.get()))
+                    .password(Property.ofValue(maybePassword.get()))
+                    .build());
             }
         } else {
-            var autoAuth = runContext.sdk().defaultAuthentication();
+            Optional<SDK.Auth> autoAuth = runContext.sdk().defaultAuthentication();
             if (autoAuth.isPresent() && autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
-                String encoded = Base64.getEncoder().encodeToString(
-                    (autoAuth.get().username().get() + ":" + autoAuth.get().password().get()).getBytes(StandardCharsets.UTF_8));
-                requestBuilder.header("Authorization", "Basic " + encoded);
+                configBuilder.auth(BasicAuthConfiguration.builder()
+                    .username(Property.ofValue(autoAuth.get().username().get()))
+                    .password(Property.ofValue(autoAuth.get().password().get()))
+                    .build());
             }
         }
 
-        var response = HttpClient.newHttpClient().send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString());
-        if (response.statusCode() != 200) {
-            throw new KestraRuntimeException("Failed to fetch dashboard YAML for " + dashboardId + ": HTTP " + response.statusCode());
+        try (var httpClient = HttpClient.builder()
+                .runContext(runContext)
+                .configuration(configBuilder.build())
+                .build()) {
+            var response = httpClient.request(
+                HttpRequest.builder()
+                    .uri(URI.create(basePath + path))
+                    .addHeader("Accept", "application/x-yaml")
+                    .build(),
+                String.class
+            );
+            return response.getBody();
         }
-        return response.body();
     }
 
     private File toNamedTempFile(String fileName, String yaml) {

--- a/src/main/java/io/kestra/plugin/git/TenantSync.java
+++ b/src/main/java/io/kestra/plugin/git/TenantSync.java
@@ -2,6 +2,9 @@ package io.kestra.plugin.git;
 
 import java.io.*;
 import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileVisitOption;
 import java.nio.file.Files;
@@ -845,9 +848,15 @@ public class TenantSync extends AbstractKestraTask implements RunnableTask<Tenan
             do {
                 pagedResults = kestraClient.dashboards().searchDashboards(page, size, runContext.flowInfo().tenantId(), null, null);
 
+                String tenantForFetch = runContext.flowInfo().tenantId();
                 pagedResults.getResults().forEach(dash ->
                 {
-                    dashboards.put(dash.getTitle(), dash.getSourceCode());
+                    try {
+                        String sourceCode = fetchDashboardSourceCode(kestraClient, runContext, tenantForFetch, dash.getId());
+                        dashboards.put(dash.getTitle(), sourceCode);
+                    } catch (Exception e) {
+                        throw new KestraRuntimeException("Failed to fetch source code for dashboard " + dash.getId(), e);
+                    }
                 });
 
                 page++;
@@ -1006,6 +1015,44 @@ public class TenantSync extends AbstractKestraTask implements RunnableTask<Tenan
                 runContext.logger().warn("{} couldn't be synced due to invalid syntax: {}", what, e.getMessage());
             case FAIL -> throw new KestraRuntimeException("Invalid syntax for " + what + ": " + e.getMessage(), e);
         }
+    }
+
+    private String fetchDashboardSourceCode(KestraClient kestraClient, RunContext runContext, String tenantId, String dashboardId) throws Exception {
+        var apiClient = kestraClient.dashboards().getApiClient();
+        String path = tenantId == null
+            ? "/api/v1/dashboards/" + dashboardId
+            : "/api/v1/" + tenantId + "/dashboards/" + dashboardId;
+        String url = apiClient.getBaseURL() + path;
+
+        var requestBuilder = HttpRequest.newBuilder()
+            .uri(URI.create(url))
+            .header("Accept", "application/x-yaml")
+            .GET();
+
+        // Apply authentication: explicit auth property first, then SDK default
+        var authProperty = getAuth();
+        if (authProperty != null) {
+            var maybeUsername = runContext.render(authProperty.getUsername()).as(String.class);
+            var maybePassword = runContext.render(authProperty.getPassword()).as(String.class);
+            if (maybeUsername.isPresent() && maybePassword.isPresent()) {
+                String encoded = Base64.getEncoder().encodeToString(
+                    (maybeUsername.get() + ":" + maybePassword.get()).getBytes(StandardCharsets.UTF_8));
+                requestBuilder.header("Authorization", "Basic " + encoded);
+            }
+        } else {
+            var autoAuth = runContext.sdk().defaultAuthentication();
+            if (autoAuth.isPresent() && autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
+                String encoded = Base64.getEncoder().encodeToString(
+                    (autoAuth.get().username().get() + ":" + autoAuth.get().password().get()).getBytes(StandardCharsets.UTF_8));
+                requestBuilder.header("Authorization", "Basic " + encoded);
+            }
+        }
+
+        var response = HttpClient.newHttpClient().send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() != 200) {
+            throw new KestraRuntimeException("Failed to fetch dashboard YAML for " + dashboardId + ": HTTP " + response.statusCode());
+        }
+        return response.body();
     }
 
     private File toNamedTempFile(String fileName, String yaml) {

--- a/src/main/java/io/kestra/plugin/git/TenantSync.java
+++ b/src/main/java/io/kestra/plugin/git/TenantSync.java
@@ -24,10 +24,7 @@ import org.eclipse.jgit.transport.RemoteRefUpdate;
 import io.kestra.core.exceptions.FlowProcessingException;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.exceptions.KestraRuntimeException;
-import io.kestra.core.http.HttpRequest;
-import io.kestra.core.http.client.HttpClient;
-import io.kestra.core.http.client.configurations.HttpConfiguration;
-import io.kestra.core.runners.SDK;
+import com.fasterxml.jackson.core.type.TypeReference;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.flows.FlowWithSource;
@@ -38,6 +35,7 @@ import io.kestra.core.serializers.YamlParser;
 import io.kestra.plugin.git.services.GitService;
 import io.kestra.sdk.KestraClient;
 import io.kestra.sdk.api.FilesApi;
+import io.kestra.sdk.internal.ApiClient;
 import io.kestra.sdk.internal.ApiException;
 import io.kestra.sdk.model.*;
 
@@ -1020,62 +1018,20 @@ public class TenantSync extends AbstractKestraTask implements RunnableTask<Tenan
     }
 
     private String fetchDashboardSourceCode(KestraClient kestraClient, RunContext runContext, String tenantId, String dashboardId) throws Exception {
-        String basePath = kestraClient.dashboards().getApiClient().getBasePath();
+        ApiClient apiClient = kestraClient.dashboards().getApiClient();
         String encodedId = URLEncoder.encode(dashboardId, StandardCharsets.UTF_8);
         String path = tenantId == null
             ? "/api/v1/dashboards/" + encodedId
             : "/api/v1/" + tenantId + "/dashboards/" + encodedId;
 
-        String username = null;
-        String password = null;
-        String apiToken = null;
-        AbstractKestraTask.Auth auth = getAuth();
-        if (auth != null) {
-            Optional<String> maybeUsername = runContext.render(auth.getUsername()).as(String.class);
-            Optional<String> maybePassword = runContext.render(auth.getPassword()).as(String.class);
-            if (maybeUsername.isPresent() && maybePassword.isPresent()) {
-                username = maybeUsername.get();
-                password = maybePassword.get();
-            } else if (runContext.render(auth.getAuto()).as(Boolean.class).orElse(Boolean.TRUE)) {
-                Optional<SDK.Auth> autoAuth = runContext.sdk().defaultAuthentication();
-                if (autoAuth.isPresent()) {
-                    if (autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
-                        username = autoAuth.get().username().get();
-                        password = autoAuth.get().password().get();
-                    } else if (autoAuth.get().apiToken().isPresent()) {
-                        apiToken = autoAuth.get().apiToken().get();
-                    }
-                }
-            }
-        } else {
-            Optional<SDK.Auth> autoAuth = runContext.sdk().defaultAuthentication();
-            if (autoAuth.isPresent()) {
-                if (autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
-                    username = autoAuth.get().username().get();
-                    password = autoAuth.get().password().get();
-                } else if (autoAuth.get().apiToken().isPresent()) {
-                    apiToken = autoAuth.get().apiToken().get();
-                }
-            }
-        }
-
-        HttpRequest.HttpRequestBuilder requestBuilder = HttpRequest.builder()
-            .uri(URI.create(basePath + path))
-            .addHeader("Accept", "application/x-yaml");
-        if (username != null && password != null) {
-            String encoded = Base64.getEncoder().encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
-            requestBuilder.addHeader("Authorization", "Basic " + encoded);
-        } else if (apiToken != null) {
-            requestBuilder.addHeader("Authorization", "Bearer " + apiToken);
-        }
-
-        try (var httpClient = HttpClient.builder()
-                .runContext(runContext)
-                .configuration(HttpConfiguration.builder().build())
-                .build()) {
-            var response = httpClient.request(requestBuilder.build(), String.class);
-            return response.getBody();
-        }
+        byte[] yamlBytes = apiClient.invokeAPI(
+            path, "GET",
+            Collections.emptyList(), Collections.emptyList(), null,
+            null, Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
+            "application/x-yaml", null, new String[0],
+            new TypeReference<byte[]>() {}
+        );
+        return new String(yamlBytes, StandardCharsets.UTF_8);
     }
 
     private File toNamedTempFile(String fileName, String yaml) {

--- a/src/main/java/io/kestra/plugin/git/TenantSync.java
+++ b/src/main/java/io/kestra/plugin/git/TenantSync.java
@@ -26,7 +26,6 @@ import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.exceptions.KestraRuntimeException;
 import io.kestra.core.http.HttpRequest;
 import io.kestra.core.http.client.HttpClient;
-import io.kestra.core.http.client.configurations.BasicAuthConfiguration;
 import io.kestra.core.http.client.configurations.HttpConfiguration;
 import io.kestra.core.runners.SDK;
 import io.kestra.core.models.annotations.Example;
@@ -1027,38 +1026,54 @@ public class TenantSync extends AbstractKestraTask implements RunnableTask<Tenan
             ? "/api/v1/dashboards/" + encodedId
             : "/api/v1/" + tenantId + "/dashboards/" + encodedId;
 
-        HttpConfiguration.HttpConfigurationBuilder configBuilder = HttpConfiguration.builder();
+        String username = null;
+        String password = null;
+        String apiToken = null;
         AbstractKestraTask.Auth auth = getAuth();
         if (auth != null) {
             Optional<String> maybeUsername = runContext.render(auth.getUsername()).as(String.class);
             Optional<String> maybePassword = runContext.render(auth.getPassword()).as(String.class);
             if (maybeUsername.isPresent() && maybePassword.isPresent()) {
-                configBuilder.auth(BasicAuthConfiguration.builder()
-                    .username(Property.ofValue(maybeUsername.get()))
-                    .password(Property.ofValue(maybePassword.get()))
-                    .build());
+                username = maybeUsername.get();
+                password = maybePassword.get();
+            } else if (runContext.render(auth.getAuto()).as(Boolean.class).orElse(Boolean.TRUE)) {
+                Optional<SDK.Auth> autoAuth = runContext.sdk().defaultAuthentication();
+                if (autoAuth.isPresent()) {
+                    if (autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
+                        username = autoAuth.get().username().get();
+                        password = autoAuth.get().password().get();
+                    } else if (autoAuth.get().apiToken().isPresent()) {
+                        apiToken = autoAuth.get().apiToken().get();
+                    }
+                }
             }
         } else {
             Optional<SDK.Auth> autoAuth = runContext.sdk().defaultAuthentication();
-            if (autoAuth.isPresent() && autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
-                configBuilder.auth(BasicAuthConfiguration.builder()
-                    .username(Property.ofValue(autoAuth.get().username().get()))
-                    .password(Property.ofValue(autoAuth.get().password().get()))
-                    .build());
+            if (autoAuth.isPresent()) {
+                if (autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
+                    username = autoAuth.get().username().get();
+                    password = autoAuth.get().password().get();
+                } else if (autoAuth.get().apiToken().isPresent()) {
+                    apiToken = autoAuth.get().apiToken().get();
+                }
             }
+        }
+
+        HttpRequest.HttpRequestBuilder requestBuilder = HttpRequest.builder()
+            .uri(URI.create(basePath + path))
+            .addHeader("Accept", "application/x-yaml");
+        if (username != null && password != null) {
+            String encoded = Base64.getEncoder().encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
+            requestBuilder.addHeader("Authorization", "Basic " + encoded);
+        } else if (apiToken != null) {
+            requestBuilder.addHeader("Authorization", "Bearer " + apiToken);
         }
 
         try (var httpClient = HttpClient.builder()
                 .runContext(runContext)
-                .configuration(configBuilder.build())
+                .configuration(HttpConfiguration.builder().build())
                 .build()) {
-            var response = httpClient.request(
-                HttpRequest.builder()
-                    .uri(URI.create(basePath + path))
-                    .addHeader("Accept", "application/x-yaml")
-                    .build(),
-                String.class
-            );
+            var response = httpClient.request(requestBuilder.build(), String.class);
             return response.getBody();
         }
     }

--- a/src/test/java/io/kestra/plugin/git/AbstractKestraContainerTest.java
+++ b/src/test/java/io/kestra/plugin/git/AbstractKestraContainerTest.java
@@ -1,0 +1,69 @@
+package io.kestra.plugin.git;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Base class for integration tests that run against a real Kestra Docker container.
+ * Complements (does not replace) the existing {@link MockKestraApiServer} tests.
+ */
+@Testcontainers
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Slf4j
+public abstract class AbstractKestraContainerTest {
+
+    protected static final String USERNAME = "admin@admin.com";
+    protected static final String PASSWORD = "Root!1234";
+
+    // kestra/kestra:v1.3-no-plugins is pinned for stability — develop has known regressions
+    @Container
+    protected static final GenericContainer<?> KESTRA_CONTAINER = new GenericContainer<>(
+        DockerImageName.parse("kestra/kestra:v1.3-no-plugins")
+    )
+        .withExposedPorts(8080)
+        .withEnv("KESTRA_SECURITY_SUPER_ADMIN_USERNAME", USERNAME)
+        .withEnv("KESTRA_SECURITY_SUPER_ADMIN_PASSWORD", PASSWORD)
+        .withEnv("KESTRA_CONFIGURATION", """
+            kestra:
+              repository:
+                type: memory
+              queue:
+                type: memory
+              storage:
+                type: local
+                local:
+                  base-path: /tmp/kestra-storage
+              server:
+                basic-auth:
+                  username: admin@admin.com
+                  password: Root!1234
+              security:
+                super-admin:
+                  username: admin@admin.com
+                  password: Root!1234
+            """)
+        .withCommand("server local")
+        .waitingFor(Wait.forHttp("/ui/login").forStatusCode(200))
+        .withLogConsumer(new Slf4jLogConsumer(log))
+        .withStartupTimeout(Duration.ofMinutes(2));
+
+    protected String kestraUrl;
+    protected KestraContainerTestDataUtils kestraTestDataUtils;
+
+    @BeforeAll
+    void setupKestra() {
+        kestraUrl = "http://" + KESTRA_CONTAINER.getHost() + ":" + KESTRA_CONTAINER.getMappedPort(8080);
+        log.info("Kestra container started at URL: {}", kestraUrl);
+        kestraTestDataUtils = new KestraContainerTestDataUtils(kestraUrl, USERNAME, PASSWORD);
+    }
+}

--- a/src/test/java/io/kestra/plugin/git/AbstractKestraContainerTest.java
+++ b/src/test/java/io/kestra/plugin/git/AbstractKestraContainerTest.java
@@ -13,26 +13,16 @@ import org.testcontainers.utility.DockerImageName;
 
 import lombok.extern.slf4j.Slf4j;
 
-/**
- * Base class for integration tests that run against a real Kestra Docker container.
- * Complements (does not replace) the existing {@link MockKestraApiServer} tests.
- */
 @Testcontainers
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @Slf4j
 public abstract class AbstractKestraContainerTest {
 
-    protected static final String USERNAME = "admin@admin.com";
-    protected static final String PASSWORD = "Root!1234";
-
-    // kestra/kestra:v1.3-no-plugins is pinned for stability — develop has known regressions
     @Container
     protected static final GenericContainer<?> KESTRA_CONTAINER = new GenericContainer<>(
-        DockerImageName.parse("kestra/kestra:v1.3-no-plugins")
+        DockerImageName.parse("kestra/kestra:develop-no-plugins")
     )
         .withExposedPorts(8080)
-        .withEnv("KESTRA_SECURITY_SUPER_ADMIN_USERNAME", USERNAME)
-        .withEnv("KESTRA_SECURITY_SUPER_ADMIN_PASSWORD", PASSWORD)
         .withEnv("KESTRA_CONFIGURATION", """
             kestra:
               repository:
@@ -43,14 +33,6 @@ public abstract class AbstractKestraContainerTest {
                 type: local
                 local:
                   base-path: /tmp/kestra-storage
-              server:
-                basic-auth:
-                  username: admin@admin.com
-                  password: Root!1234
-              security:
-                super-admin:
-                  username: admin@admin.com
-                  password: Root!1234
             """)
         .withCommand("server local")
         .waitingFor(Wait.forHttp("/ui/login").forStatusCode(200))
@@ -64,6 +46,6 @@ public abstract class AbstractKestraContainerTest {
     void setupKestra() {
         kestraUrl = "http://" + KESTRA_CONTAINER.getHost() + ":" + KESTRA_CONTAINER.getMappedPort(8080);
         log.info("Kestra container started at URL: {}", kestraUrl);
-        kestraTestDataUtils = new KestraContainerTestDataUtils(kestraUrl, USERNAME, PASSWORD);
+        kestraTestDataUtils = new KestraContainerTestDataUtils(kestraUrl);
     }
 }

--- a/src/test/java/io/kestra/plugin/git/AbstractKestraContainerTest.java
+++ b/src/test/java/io/kestra/plugin/git/AbstractKestraContainerTest.java
@@ -18,11 +18,16 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public abstract class AbstractKestraContainerTest {
 
+    protected static final String USERNAME = "admin@admin.com";
+    protected static final String PASSWORD = "Root!1234";
+
     @Container
     protected static final GenericContainer<?> KESTRA_CONTAINER = new GenericContainer<>(
-        DockerImageName.parse("kestra/kestra:develop-no-plugins")
+        DockerImageName.parse("kestra/kestra:v1.3-no-plugins")
     )
         .withExposedPorts(8080)
+        .withEnv("KESTRA_SECURITY_SUPER_ADMIN_USERNAME", USERNAME)
+        .withEnv("KESTRA_SECURITY_SUPER_ADMIN_PASSWORD", PASSWORD)
         .withEnv("KESTRA_CONFIGURATION", """
             kestra:
               repository:
@@ -33,6 +38,14 @@ public abstract class AbstractKestraContainerTest {
                 type: local
                 local:
                   base-path: /tmp/kestra-storage
+              server:
+                basic-auth:
+                  username: admin@admin.com
+                  password: Root!1234
+              security:
+                super-admin:
+                  username: admin@admin.com
+                  password: Root!1234
             """)
         .withCommand("server local")
         .waitingFor(Wait.forHttp("/ui/login").forStatusCode(200))
@@ -46,6 +59,6 @@ public abstract class AbstractKestraContainerTest {
     void setupKestra() {
         kestraUrl = "http://" + KESTRA_CONTAINER.getHost() + ":" + KESTRA_CONTAINER.getMappedPort(8080);
         log.info("Kestra container started at URL: {}", kestraUrl);
-        kestraTestDataUtils = new KestraContainerTestDataUtils(kestraUrl);
+        kestraTestDataUtils = new KestraContainerTestDataUtils(kestraUrl, USERNAME, PASSWORD);
     }
 }

--- a/src/test/java/io/kestra/plugin/git/AbstractKestraContainerTest.java
+++ b/src/test/java/io/kestra/plugin/git/AbstractKestraContainerTest.java
@@ -20,6 +20,7 @@ public abstract class AbstractKestraContainerTest {
 
     protected static final String USERNAME = "admin@admin.com";
     protected static final String PASSWORD = "Root!1234";
+    protected static final String TENANT_ID = "main";
 
     @Container
     protected static final GenericContainer<?> KESTRA_CONTAINER = new GenericContainer<>(

--- a/src/test/java/io/kestra/plugin/git/AbstractKestraContainerTest.java
+++ b/src/test/java/io/kestra/plugin/git/AbstractKestraContainerTest.java
@@ -23,7 +23,7 @@ public abstract class AbstractKestraContainerTest {
 
     @Container
     protected static final GenericContainer<?> KESTRA_CONTAINER = new GenericContainer<>(
-        DockerImageName.parse("kestra/kestra:v1.3-no-plugins")
+        DockerImageName.parse("kestra/kestra:develop-no-plugins")
     )
         .withExposedPorts(8080)
         .withEnv("KESTRA_SECURITY_SUPER_ADMIN_USERNAME", USERNAME)

--- a/src/test/java/io/kestra/plugin/git/DashboardUtils.java
+++ b/src/test/java/io/kestra/plugin/git/DashboardUtils.java
@@ -47,6 +47,7 @@ public class DashboardUtils {
             """;
         Dashboard dashboard = YamlParser.parse(dashboardSource, Dashboard.class).toBuilder()
             .tenantId(tenantId)
+            .updated(java.time.Instant.now())
             .build();
 
         return dashboardRepositoryInterface.save(dashboard, dashboardSource);

--- a/src/test/java/io/kestra/plugin/git/KestraContainerTestDataUtils.java
+++ b/src/test/java/io/kestra/plugin/git/KestraContainerTestDataUtils.java
@@ -6,28 +6,16 @@ import io.kestra.sdk.KestraClient;
 import io.kestra.sdk.internal.ApiException;
 import io.kestra.sdk.model.Flow;
 
-/**
- * Minimal helper for Kestra API interactions in container-based integration tests.
- * Wraps {@link KestraClient} with basic auth to create and query test data.
- */
 public class KestraContainerTestDataUtils {
 
     private final KestraClient kestraClient;
 
-    public KestraContainerTestDataUtils(String kestraUrl, String username, String password) {
+    public KestraContainerTestDataUtils(String kestraUrl) {
         this.kestraClient = KestraClient.builder()
             .url(kestraUrl)
-            .basicAuth(username, password)
             .build();
     }
 
-    /**
-     * Lists all flows belonging to the given namespace for the given tenant.
-     *
-     * @param namespace namespace to query (exact match)
-     * @param tenantId  tenant identifier, or {@code null} for the default tenant
-     * @return list of flows found in that namespace
-     */
     public List<Flow> listFlowsByNamespace(String namespace, String tenantId) throws ApiException {
         return kestraClient.flows().listFlowsByNamespace(namespace, tenantId);
     }

--- a/src/test/java/io/kestra/plugin/git/KestraContainerTestDataUtils.java
+++ b/src/test/java/io/kestra/plugin/git/KestraContainerTestDataUtils.java
@@ -39,4 +39,8 @@ public class KestraContainerTestDataUtils {
             Files.deleteIfExists(tmp);
         }
     }
+
+    public void createDashboard(String tenantId, String dashboardYaml) throws ApiException {
+        kestraClient.dashboards().createDashboard(tenantId, dashboardYaml);
+    }
 }

--- a/src/test/java/io/kestra/plugin/git/KestraContainerTestDataUtils.java
+++ b/src/test/java/io/kestra/plugin/git/KestraContainerTestDataUtils.java
@@ -1,0 +1,34 @@
+package io.kestra.plugin.git;
+
+import java.util.List;
+
+import io.kestra.sdk.KestraClient;
+import io.kestra.sdk.internal.ApiException;
+import io.kestra.sdk.model.Flow;
+
+/**
+ * Minimal helper for Kestra API interactions in container-based integration tests.
+ * Wraps {@link KestraClient} with basic auth to create and query test data.
+ */
+public class KestraContainerTestDataUtils {
+
+    private final KestraClient kestraClient;
+
+    public KestraContainerTestDataUtils(String kestraUrl, String username, String password) {
+        this.kestraClient = KestraClient.builder()
+            .url(kestraUrl)
+            .basicAuth(username, password)
+            .build();
+    }
+
+    /**
+     * Lists all flows belonging to the given namespace for the given tenant.
+     *
+     * @param namespace namespace to query (exact match)
+     * @param tenantId  tenant identifier, or {@code null} for the default tenant
+     * @return list of flows found in that namespace
+     */
+    public List<Flow> listFlowsByNamespace(String namespace, String tenantId) throws ApiException {
+        return kestraClient.flows().listFlowsByNamespace(namespace, tenantId);
+    }
+}

--- a/src/test/java/io/kestra/plugin/git/KestraContainerTestDataUtils.java
+++ b/src/test/java/io/kestra/plugin/git/KestraContainerTestDataUtils.java
@@ -10,9 +10,10 @@ public class KestraContainerTestDataUtils {
 
     private final KestraClient kestraClient;
 
-    public KestraContainerTestDataUtils(String kestraUrl) {
+    public KestraContainerTestDataUtils(String kestraUrl, String username, String password) {
         this.kestraClient = KestraClient.builder()
             .url(kestraUrl)
+            .basicAuth(username, password)
             .build();
     }
 

--- a/src/test/java/io/kestra/plugin/git/KestraContainerTestDataUtils.java
+++ b/src/test/java/io/kestra/plugin/git/KestraContainerTestDataUtils.java
@@ -1,5 +1,9 @@
 package io.kestra.plugin.git;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.List;
 
 import io.kestra.sdk.KestraClient;
@@ -19,5 +23,20 @@ public class KestraContainerTestDataUtils {
 
     public List<Flow> listFlowsByNamespace(String namespace, String tenantId) throws ApiException {
         return kestraClient.flows().listFlowsByNamespace(namespace, tenantId);
+    }
+
+    /**
+     * Imports a flow into the Kestra container using the SDK's importFlows API.
+     * The YAML is written to a named temp file so the API can infer the flow id.
+     * Passing {@code false} as the first argument performs an additive (non-destructive) import.
+     */
+    public void createFlow(String tenantId, String flowYaml) throws ApiException, IOException {
+        var tmp = Files.createTempFile("kestra-flow-", ".yaml");
+        try {
+            Files.writeString(tmp, flowYaml, StandardCharsets.UTF_8);
+            kestraClient.flows().importFlows(false, tenantId, tmp.toFile());
+        } finally {
+            Files.deleteIfExists(tmp);
+        }
     }
 }

--- a/src/test/java/io/kestra/plugin/git/MockKestraApiServer.java
+++ b/src/test/java/io/kestra/plugin/git/MockKestraApiServer.java
@@ -178,17 +178,23 @@ public class MockKestraApiServer implements AutoCloseable {
             flows = flows.stream().filter(f -> fId.equals(f.getId())).toList();
         }
 
+        // Deduplicate: keep only the latest revision per (namespace, id)
+        Map<String, FlowWithSource> latest = new java.util.LinkedHashMap<>();
+        for (var f : flows) {
+            String key = f.getNamespace() + "." + f.getId();
+            FlowWithSource existing = latest.get(key);
+            if (existing == null || (f.getRevision() != null && (existing.getRevision() == null || f.getRevision() > existing.getRevision()))) {
+                latest.put(key, f);
+            }
+        }
+        flows = new java.util.ArrayList<>(latest.values());
+
         var baos = new ByteArrayOutputStream();
         try (var zos = new ZipOutputStream(baos)) {
             for (var f : flows) {
                 var source = f.getSource();
                 if (source == null || source.isBlank()) {
-                    // Build a minimal YAML with revision so the parsed flow has a non-null revision
-                    source = "id: " + f.getId() + "\nnamespace: " + f.getNamespace()
-                        + "\nrevision: " + (f.getRevision() != null ? f.getRevision() : 1) + "\n";
-                } else if (!FLOW_REVISION_PATTERN.matcher(source).find() && f.getRevision() != null) {
-                    // Inject revision into the source YAML when it's missing
-                    source = "revision: " + f.getRevision() + "\n" + source;
+                    source = "id: " + f.getId() + "\nnamespace: " + f.getNamespace() + "\n";
                 }
                 var bytes = source.getBytes(StandardCharsets.UTF_8);
                 zos.putNextEntry(new ZipEntry(f.getNamespace() + "." + f.getId() + ".yml"));

--- a/src/test/java/io/kestra/plugin/git/MockKestraApiServer.java
+++ b/src/test/java/io/kestra/plugin/git/MockKestraApiServer.java
@@ -203,13 +203,15 @@ public class MockKestraApiServer implements AutoCloseable {
                 if (!FLOW_REVISION_PATTERN.matcher(source).find() && f.getRevision() != null) {
                     source = "revision: " + f.getRevision() + "\n" + source;
                 }
-                // Skip flows whose source YAML id/namespace doesn't match the actual flow
+                // Fix flows whose source YAML id/namespace doesn't match the actual flow
                 // (test flows with inconsistent source cause Duplicate key in AbstractSyncTask.beforeUpdateResourcesByUri)
                 Matcher srcIdMatcher = FLOW_ID_PATTERN.matcher(source);
+                if (srcIdMatcher.find() && !f.getId().equals(srcIdMatcher.group(1).trim())) {
+                    source = FLOW_ID_PATTERN.matcher(source).replaceFirst("id: " + f.getId());
+                }
                 Matcher srcNsMatcher = FLOW_NS_PATTERN.matcher(source);
-                if ((srcIdMatcher.find() && !f.getId().equals(srcIdMatcher.group(1).trim()))
-                    || (srcNsMatcher.find() && !f.getNamespace().equals(srcNsMatcher.group(1).trim()))) {
-                    continue;
+                if (srcNsMatcher.find() && !f.getNamespace().equals(srcNsMatcher.group(1).trim())) {
+                    source = FLOW_NS_PATTERN.matcher(source).replaceFirst("namespace: " + f.getNamespace());
                 }
                 var bytes = source.getBytes(StandardCharsets.UTF_8);
                 zos.putNextEntry(new ZipEntry(f.getNamespace() + "." + f.getId() + ".yml"));
@@ -381,8 +383,9 @@ public class MockKestraApiServer implements AutoCloseable {
             var d = match.get();
             var sourceYaml = d.getSourceCode();
             // Inject updated timestamp into YAML so SyncDashboards.wrapper() can compare without NPE
-            if (d.getUpdated() != null && !sourceYaml.contains("\nupdated:") && !sourceYaml.startsWith("updated:")) {
-                sourceYaml = "updated: " + d.getUpdated() + "\n" + sourceYaml;
+            if (!sourceYaml.contains("\nupdated:") && !sourceYaml.startsWith("updated:")) {
+                var ts = d.getUpdated() != null ? d.getUpdated().toString() : "1970-01-01T00:00:00Z";
+                sourceYaml = "updated: " + ts + "\n" + sourceYaml;
             }
             var yaml = sourceYaml.getBytes(StandardCharsets.UTF_8);
             exchange.getResponseHeaders().set("Content-Type", "application/x-yaml");

--- a/src/test/java/io/kestra/plugin/git/MockKestraApiServer.java
+++ b/src/test/java/io/kestra/plugin/git/MockKestraApiServer.java
@@ -199,6 +199,10 @@ public class MockKestraApiServer implements AutoCloseable {
                 if (source == null || source.isBlank()) {
                     source = "id: " + f.getId() + "\nnamespace: " + f.getNamespace() + "\n";
                 }
+                // Inject revision so SyncFlows.wrapper() can call getRevision() without NPE
+                if (!FLOW_REVISION_PATTERN.matcher(source).find() && f.getRevision() != null) {
+                    source = "revision: " + f.getRevision() + "\n" + source;
+                }
                 var bytes = source.getBytes(StandardCharsets.UTF_8);
                 zos.putNextEntry(new ZipEntry(f.getNamespace() + "." + f.getId() + ".yml"));
                 zos.write(bytes);
@@ -366,7 +370,13 @@ public class MockKestraApiServer implements AutoCloseable {
         var dashboards = dashboardRepo.findAll(tenantId);
         var match = dashboards.stream().filter(d -> dashboardId.equals(d.getId())).findFirst();
         if (match.isPresent() && match.get().getSourceCode() != null) {
-            var yaml = match.get().getSourceCode().getBytes(StandardCharsets.UTF_8);
+            var d = match.get();
+            var sourceYaml = d.getSourceCode();
+            // Inject updated timestamp into YAML so SyncDashboards.wrapper() can compare without NPE
+            if (d.getUpdated() != null && !sourceYaml.contains("\nupdated:") && !sourceYaml.startsWith("updated:")) {
+                sourceYaml = "updated: " + d.getUpdated() + "\n" + sourceYaml;
+            }
+            var yaml = sourceYaml.getBytes(StandardCharsets.UTF_8);
             exchange.getResponseHeaders().set("Content-Type", "application/x-yaml");
             exchange.sendResponseHeaders(200, yaml.length);
             exchange.getResponseBody().write(yaml);

--- a/src/test/java/io/kestra/plugin/git/MockKestraApiServer.java
+++ b/src/test/java/io/kestra/plugin/git/MockKestraApiServer.java
@@ -203,6 +203,14 @@ public class MockKestraApiServer implements AutoCloseable {
                 if (!FLOW_REVISION_PATTERN.matcher(source).find() && f.getRevision() != null) {
                     source = "revision: " + f.getRevision() + "\n" + source;
                 }
+                // Skip flows whose source YAML id/namespace doesn't match the actual flow
+                // (test flows with inconsistent source cause Duplicate key in AbstractSyncTask.beforeUpdateResourcesByUri)
+                Matcher srcIdMatcher = FLOW_ID_PATTERN.matcher(source);
+                Matcher srcNsMatcher = FLOW_NS_PATTERN.matcher(source);
+                if ((srcIdMatcher.find() && !f.getId().equals(srcIdMatcher.group(1).trim()))
+                    || (srcNsMatcher.find() && !f.getNamespace().equals(srcNsMatcher.group(1).trim()))) {
+                    continue;
+                }
                 var bytes = source.getBytes(StandardCharsets.UTF_8);
                 zos.putNextEntry(new ZipEntry(f.getNamespace() + "." + f.getId() + ".yml"));
                 zos.write(bytes);
@@ -406,7 +414,21 @@ public class MockKestraApiServer implements AutoCloseable {
                     .tenantId(tenantId)
                     .sourceCode(yamlBody)
                     .build();
-                dashboardRepo.save(parsed, yamlBody);
+                // Preserve updated timestamp if content is unchanged, otherwise set now
+                var existing = dashboardRepo.findAll(tenantId).stream()
+                    .filter(d -> d.getId().equals(parsed.getId()))
+                    .findFirst()
+                    .orElse(null);
+                java.time.Instant updated;
+                if (existing != null
+                    && existing.getSourceCode() != null
+                    && existing.getSourceCode().strip().equals(yamlBody.strip())) {
+                    // Same content — preserve existing timestamp (use EPOCH if null so handleGetDashboardYaml fallback matches)
+                    updated = existing.getUpdated() != null ? existing.getUpdated() : java.time.Instant.EPOCH;
+                } else {
+                    updated = java.time.Instant.now();
+                }
+                dashboardRepo.save(parsed.toBuilder().updated(updated).build(), yamlBody);
             } catch (Exception e) {
                 // log and ignore parse errors
             }

--- a/src/test/java/io/kestra/plugin/git/MockKestraApiServer.java
+++ b/src/test/java/io/kestra/plugin/git/MockKestraApiServer.java
@@ -1,0 +1,507 @@
+package io.kestra.plugin.git;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+
+import io.kestra.core.models.dashboards.Dashboard;
+import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.flows.FlowWithSource;
+import io.kestra.core.models.flows.GenericFlow;
+import io.kestra.core.repositories.DashboardRepositoryInterface;
+import io.kestra.core.repositories.FlowRepositoryInterface;
+import io.kestra.core.serializers.JacksonMapper;
+import io.kestra.core.serializers.YamlParser;
+import io.kestra.core.tenant.TenantService;
+
+/**
+ * In-process HTTP server that bridges Kestra SDK calls to in-memory repository beans.
+ * Used in integration tests to avoid requiring a real Kestra server.
+ */
+public class MockKestraApiServer implements AutoCloseable {
+
+    private static final Pattern NAMESPACE_FILTER_PATTERN = Pattern.compile("NAMESPACE,[^,]+,(.+?)(?:&|$)");
+    private static final Pattern ID_FILTER_PATTERN = Pattern.compile("ID,[^,]+,(.+?)(?:&|$)");
+    private static final Pattern FLOW_ID_PATTERN = Pattern.compile("(?m)^id:\\s*(.+)$");
+    private static final Pattern FLOW_NS_PATTERN = Pattern.compile("(?m)^namespace:\\s*(.+)$");
+    // Matches multipart boundary lines to extract file content
+    private static final Pattern MULTIPART_BOUNDARY_PATTERN = Pattern.compile("boundary=([^\\r\\n;]+)");
+
+    private final HttpServer server;
+    private final FlowRepositoryInterface flowRepo;
+    private final DashboardRepositoryInterface dashboardRepo;
+
+    private MockKestraApiServer(FlowRepositoryInterface flowRepo, DashboardRepositoryInterface dashboardRepo) throws IOException {
+        this.flowRepo = flowRepo;
+        this.dashboardRepo = dashboardRepo;
+        this.server = HttpServer.create(new InetSocketAddress(0), 0);
+        registerHandlers();
+        this.server.start();
+    }
+
+    /**
+     * Creates and starts a mock server backed by the given repositories.
+     * Call {@link #close()} when the test finishes.
+     */
+    public static MockKestraApiServer start(FlowRepositoryInterface flowRepo, DashboardRepositoryInterface dashboardRepo) throws IOException {
+        return new MockKestraApiServer(flowRepo, dashboardRepo);
+    }
+
+    /**
+     * Creates and starts a mock server backed only by the flow repository (dashboards not needed).
+     */
+    public static MockKestraApiServer start(FlowRepositoryInterface flowRepo) throws IOException {
+        return new MockKestraApiServer(flowRepo, null);
+    }
+
+    /**
+     * Creates and starts a mock server backed only by the dashboard repository (flows not needed).
+     */
+    public static MockKestraApiServer start(DashboardRepositoryInterface dashboardRepo) throws IOException {
+        return new MockKestraApiServer(null, dashboardRepo);
+    }
+
+    /** Returns the base URL of this mock server, e.g. {@code http://localhost:54321}. */
+    public String url() {
+        return "http://localhost:" + server.getAddress().getPort();
+    }
+
+    @Override
+    public void close() {
+        server.stop(0);
+    }
+
+    // ---- handler registration -----------------------------------------------
+
+    private void registerHandlers() {
+        // flows: export, import, validate, delete
+        server.createContext("/api/v1/", exchange -> {
+            var path = exchange.getRequestURI().getPath();
+            var method = exchange.getRequestMethod();
+
+            try {
+                if (path.contains("/flows/export/by-query") && "GET".equals(method)) {
+                    handleExportFlows(exchange);
+                } else if (path.contains("/flows/import") && "POST".equals(method)) {
+                    handleImportFlows(exchange);
+                } else if (path.contains("/flows/validate") && "POST".equals(method)) {
+                    handleValidateFlows(exchange);
+                } else if (path.contains("/flows/") && "DELETE".equals(method) && !path.contains("/flows/delete")) {
+                    handleDeleteFlow(exchange);
+                } else if (path.contains("/namespaces/") && "GET".equals(method) && !path.contains("/secrets") && !path.contains("/plugindefaults") && !path.contains("/inherited")) {
+                    handleGetNamespace(exchange);
+                } else if (path.contains("/dashboards") && "GET".equals(method) && !path.contains("/charts") && !path.contains("/export")) {
+                    handleSearchOrGetDashboard(exchange, path);
+                } else if (path.contains("/dashboards") && "POST".equals(method)) {
+                    handleCreateDashboard(exchange, path);
+                } else if (path.contains("/dashboards/") && "DELETE".equals(method)) {
+                    handleDeleteDashboard(exchange, path);
+                } else {
+                    // Unknown — return 200 with empty JSON to avoid connection-refused failures
+                    sendJson(exchange, 200, "{}");
+                }
+            } catch (Exception e) {
+                try {
+                    sendJson(exchange, 500, "{\"error\": \"" + e.getMessage().replace("\"", "'") + "\"}");
+                } catch (Exception ignored) {
+                    // best effort
+                }
+            }
+        });
+    }
+
+    // ---- flow handlers -------------------------------------------------------
+
+    /**
+     * GET /api/v1/{tenantId}/flows/export/by-query?filters=NAMESPACE,EQUALS,...
+     * Returns a ZIP archive of flow YAML files from the in-memory repo.
+     */
+    private void handleExportFlows(HttpExchange exchange) throws IOException {
+        var query = exchange.getRequestURI().getRawQuery();
+        var tenantId = extractTenantId(exchange.getRequestURI().getPath(), "flows");
+
+        // Parse namespace filter (EQUALS or STARTS_WITH)
+        String namespace = null;
+        boolean startsWithMode = false;
+        if (query != null) {
+            Matcher nsMatcher = Pattern.compile("NAMESPACE,([^,]+),([^&]+)").matcher(query);
+            if (nsMatcher.find()) {
+                startsWithMode = "STARTS_WITH".equals(decode(nsMatcher.group(1)));
+                namespace = decode(nsMatcher.group(2));
+            }
+        }
+
+        // Parse optional ID filter
+        String flowIdFilter = null;
+        if (query != null) {
+            Matcher idMatcher = Pattern.compile("ID,[^,]+,([^&]+)").matcher(query);
+            if (idMatcher.find()) {
+                flowIdFilter = decode(idMatcher.group(1));
+            }
+        }
+
+        if (flowRepo == null) {
+            sendJson(exchange, 200, "{}");
+            return;
+        }
+
+        List<FlowWithSource> flows;
+        if (namespace == null || namespace.isBlank()) {
+            flows = flowRepo.findAllForAllTenants().stream()
+                .filter(f -> f instanceof FlowWithSource)
+                .map(f -> (FlowWithSource) f)
+                .toList();
+        } else if (startsWithMode) {
+            flows = flowRepo.findByNamespacePrefixWithSource(tenantId, namespace);
+        } else {
+            flows = flowRepo.findByNamespaceWithSource(tenantId, namespace);
+        }
+
+        // Apply optional ID filter
+        if (flowIdFilter != null) {
+            var fId = flowIdFilter;
+            flows = flows.stream().filter(f -> fId.equals(f.getId())).toList();
+        }
+
+        var baos = new ByteArrayOutputStream();
+        try (var zos = new ZipOutputStream(baos)) {
+            for (var f : flows) {
+                var source = f.getSource();
+                if (source == null || source.isBlank()) {
+                    // Build a minimal YAML from the flow model
+                    source = "id: " + f.getId() + "\nnamespace: " + f.getNamespace() + "\n";
+                }
+                var bytes = source.getBytes(StandardCharsets.UTF_8);
+                zos.putNextEntry(new ZipEntry(f.getNamespace() + "." + f.getId() + ".yml"));
+                zos.write(bytes);
+                zos.closeEntry();
+            }
+        }
+
+        var body = baos.toByteArray();
+        exchange.getResponseHeaders().set("Content-Type", "application/octet-stream");
+        exchange.sendResponseHeaders(200, body.length);
+        exchange.getResponseBody().write(body);
+        exchange.close();
+    }
+
+    /**
+     * POST /api/v1/{tenantId}/flows/import (multipart/form-data with fileUpload field)
+     * Parses the YAML from the multipart body and saves it to the in-memory repo.
+     */
+    private void handleImportFlows(HttpExchange exchange) throws IOException {
+        var tenantId = extractTenantId(exchange.getRequestURI().getPath(), "flows");
+        var contentType = exchange.getRequestHeaders().getFirst("Content-Type");
+        var body = exchange.getRequestBody().readAllBytes();
+
+        String yaml = extractYamlFromMultipart(contentType, body);
+        if (flowRepo != null && yaml != null && !yaml.isBlank()) {
+            importYaml(tenantId, yaml);
+        }
+
+        var responseBody = "[]".getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        exchange.sendResponseHeaders(200, responseBody.length);
+        exchange.getResponseBody().write(responseBody);
+        exchange.close();
+    }
+
+    /**
+     * POST /api/v1/{tenantId}/flows/validate (text/yaml body)
+     * Returns validation results. Detects invalid flows by checking for "unknown." type prefix.
+     */
+    private void handleValidateFlows(HttpExchange exchange) throws IOException {
+        var body = new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
+        exchange.getRequestBody().close();
+
+        // Detect invalid flow: any task type that looks like "unknown.*" is treated as invalid
+        boolean isInvalid = body.contains("type: unknown.") || body.contains("type: io.kestra.plugin.core.log.Invalid");
+
+        String jsonResponse;
+        if (isInvalid) {
+            // Return a violation with a non-null constraints field
+            jsonResponse = """
+                [{"index":0,"constraints":"Invalid task type: unknown or unregistered plugin","flow":null,"namespace":null}]
+                """.strip();
+        } else {
+            // Return a single entry with null constraints (valid)
+            jsonResponse = """
+                [{"index":0,"constraints":null,"flow":null,"namespace":null}]
+                """.strip();
+        }
+
+        var responseBody = jsonResponse.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        exchange.sendResponseHeaders(200, responseBody.length);
+        exchange.getResponseBody().write(responseBody);
+        exchange.close();
+    }
+
+    /**
+     * DELETE /api/v1/{tenantId}/flows/{namespace}/{id}
+     * Deletes the flow from the in-memory repo.
+     */
+    private void handleDeleteFlow(HttpExchange exchange) throws IOException {
+        exchange.getRequestBody().readAllBytes();
+
+        if (flowRepo != null) {
+            var path = exchange.getRequestURI().getPath();
+
+            // Path: /api/v1/{tenant}/flows/{namespace}/{id}
+            var parts = path.split("/");
+            // parts[0]="" [1]="api" [2]="v1" [3]=tenant [4]="flows" [5]=namespace [6]=id
+            if (parts.length >= 7) {
+                var tenantId = decode(parts[3]);
+                var namespace = decode(parts[5]);
+                var flowId = decode(parts[6]);
+                var flows = flowRepo.findByNamespaceWithSource(tenantId, namespace).stream()
+                    .filter(f -> flowId.equals(f.getId()))
+                    .toList();
+                for (var flow : flows) {
+                    flowRepo.delete(flow);
+                }
+            }
+        }
+
+        exchange.sendResponseHeaders(200, -1);
+        exchange.close();
+    }
+
+    /**
+     * GET /api/v1/{tenantId}/namespaces/{id}
+     * Returns a minimal namespace JSON to indicate it exists.
+     */
+    private void handleGetNamespace(HttpExchange exchange) throws IOException {
+        exchange.getRequestBody().readAllBytes();
+        var path = exchange.getRequestURI().getPath();
+        var parts = path.split("/");
+        // parts: ["", "api", "v1", tenant, "namespaces", id]
+        var namespaceId = parts.length >= 6 ? decode(parts[5]) : "unknown";
+        var json = "{\"id\":\"" + namespaceId + "\"}";
+        sendJson(exchange, 200, json);
+    }
+
+    // ---- dashboard handlers -------------------------------------------------
+
+    /**
+     * GET /api/v1/{tenantId}/dashboards?page=&size= → search (paged)
+     * GET /api/v1/{tenantId}/dashboards/{id} with Accept: application/x-yaml → YAML fetch
+     */
+    private void handleSearchOrGetDashboard(HttpExchange exchange, String path) throws IOException {
+        exchange.getRequestBody().readAllBytes();
+        var tenantId = extractTenantId(path, "dashboards");
+
+        // Check if the path ends with a dashboard id (not just the base /dashboards path)
+        var parts = path.split("/");
+        // /api/v1/{tenant}/dashboards -> parts[4]="dashboards", length=5
+        // /api/v1/{tenant}/dashboards/{id} -> parts[5]=id, length=6
+        var isDashboardById = parts.length >= 6 && !"dashboards".equals(parts[5]);
+
+        if (isDashboardById) {
+            // Single dashboard YAML fetch (Accept: application/x-yaml)
+            var dashboardId = decode(parts[5]);
+            handleGetDashboardYaml(exchange, tenantId, dashboardId);
+        } else {
+            // Paged search
+            handleSearchDashboards(exchange, tenantId);
+        }
+    }
+
+    private void handleSearchDashboards(HttpExchange exchange, String tenantId) throws IOException {
+        if (dashboardRepo == null) {
+            sendJson(exchange, 200, "{\"results\":[],\"total\":0}");
+            return;
+        }
+
+        var dashboards = dashboardRepo.findAll(tenantId);
+        var sb = new StringBuilder("{\"results\":[");
+        for (int i = 0; i < dashboards.size(); i++) {
+            var d = dashboards.get(i);
+            if (i > 0) sb.append(",");
+            sb.append("{\"id\":\"").append(d.getId()).append("\",\"title\":\"").append(d.getId()).append("\"}");
+        }
+        sb.append("],\"total\":").append(dashboards.size()).append("}");
+        sendJson(exchange, 200, sb.toString());
+    }
+
+    private void handleGetDashboardYaml(HttpExchange exchange, String tenantId, String dashboardId) throws IOException {
+        if (dashboardRepo == null) {
+            exchange.sendResponseHeaders(404, -1);
+            exchange.close();
+            return;
+        }
+
+        var dashboards = dashboardRepo.findAll(tenantId);
+        var match = dashboards.stream().filter(d -> dashboardId.equals(d.getId())).findFirst();
+        if (match.isPresent() && match.get().getSourceCode() != null) {
+            var yaml = match.get().getSourceCode().getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().set("Content-Type", "application/x-yaml");
+            exchange.sendResponseHeaders(200, yaml.length);
+            exchange.getResponseBody().write(yaml);
+        } else if (match.isPresent()) {
+            // If no source code in memory, generate minimal YAML
+            var yaml = ("id: " + dashboardId + "\ntitle: " + dashboardId + "\n").getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().set("Content-Type", "application/x-yaml");
+            exchange.sendResponseHeaders(200, yaml.length);
+            exchange.getResponseBody().write(yaml);
+        } else {
+            exchange.sendResponseHeaders(404, -1);
+        }
+        exchange.close();
+    }
+
+    /**
+     * POST /api/v1/{tenantId}/dashboards — create or update dashboard.
+     */
+    private void handleCreateDashboard(HttpExchange exchange, String path) throws IOException {
+        var tenantId = extractTenantId(path, "dashboards");
+        var yamlBody = new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
+
+        if (dashboardRepo != null && !yamlBody.isBlank()) {
+            try {
+                var parsed = YamlParser.parse(yamlBody, Dashboard.class).toBuilder()
+                    .tenantId(tenantId)
+                    .sourceCode(yamlBody)
+                    .build();
+                dashboardRepo.save(parsed, yamlBody);
+            } catch (Exception e) {
+                // log and ignore parse errors
+            }
+        }
+
+        sendJson(exchange, 200, "{\"id\":\"created\"}");
+    }
+
+    /**
+     * DELETE /api/v1/{tenantId}/dashboards/{id}
+     */
+    private void handleDeleteDashboard(HttpExchange exchange, String path) throws IOException {
+        exchange.getRequestBody().readAllBytes();
+        if (dashboardRepo != null) {
+            var parts = path.split("/");
+            if (parts.length >= 6) {
+                var tenantId = decode(parts[3]);
+                var dashboardId = decode(parts[5]);
+                dashboardRepo.delete(tenantId, dashboardId);
+            }
+        }
+        exchange.sendResponseHeaders(200, -1);
+        exchange.close();
+    }
+
+    // ---- utility ------------------------------------------------------------
+
+    /** Extracts tenantId from a path like /api/v1/{tenant}/flows/... */
+    private static String extractTenantId(String path, String resourceSegment) {
+        // Path: /api/v1/{tenant}/{resourceSegment}/...
+        var parts = path.split("/");
+        // parts[0]="" [1]="api" [2]="v1" [3]=tenant [4]=resource
+        return parts.length >= 4 ? decode(parts[3]) : TenantService.MAIN_TENANT;
+    }
+
+    private static String decode(String s) {
+        try {
+            return java.net.URLDecoder.decode(s, StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            return s;
+        }
+    }
+
+    private static void sendJson(HttpExchange exchange, int status, String json) throws IOException {
+        var bytes = json.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        exchange.sendResponseHeaders(status, bytes.length);
+        exchange.getResponseBody().write(bytes);
+        exchange.close();
+    }
+
+    /**
+     * Imports a YAML flow into the in-memory repository.
+     * Handles both create and update via {@link FlowRepositoryInterface#create}.
+     */
+    private void importYaml(String tenantId, String yaml) {
+        try {
+            var flow = YamlParser.parse(yaml, Flow.class);
+            var existing = flowRepo.findByNamespaceWithSource(tenantId, flow.getNamespace())
+                .stream()
+                .filter(f -> f.getId().equals(flow.getId()))
+                .findFirst();
+
+            if (existing.isPresent()) {
+                // Update: create a new revision
+                var updated = GenericFlow.fromYaml(tenantId, yaml);
+                flowRepo.update(updated.toBuilder().source(yaml.stripTrailing()).build(), existing.get());
+            } else {
+                var created = GenericFlow.fromYaml(tenantId, yaml);
+                flowRepo.create(created.toBuilder().source(yaml.stripTrailing()).build());
+            }
+        } catch (Exception e) {
+            // Invalid YAML — silently skip (validated separately)
+        }
+    }
+
+    /**
+     * Extracts YAML content from a multipart/form-data body.
+     * Falls back to treating the whole body as YAML if parsing fails.
+     */
+    private static String extractYamlFromMultipart(String contentType, byte[] body) {
+        if (contentType == null) {
+            return new String(body, StandardCharsets.UTF_8);
+        }
+
+        // Try to extract boundary
+        var m = MULTIPART_BOUNDARY_PATTERN.matcher(contentType);
+        if (!m.find()) {
+            return new String(body, StandardCharsets.UTF_8);
+        }
+
+        var boundary = "--" + m.group(1).trim();
+        var bodyStr = new String(body, StandardCharsets.UTF_8);
+
+        // Find the YAML part after the Content-Disposition / Content-Type headers
+        // Look for the section after the blank line that follows the headers
+        int yamlStart = -1;
+        var lines = bodyStr.split("\r\n|\n");
+        boolean inPart = false;
+        boolean pastHeaders = false;
+        var yamlBuilder = new StringBuilder();
+
+        for (var line : lines) {
+            if (line.startsWith(boundary)) {
+                if (inPart && pastHeaders && !yamlBuilder.isEmpty()) {
+                    // We already collected content — stop at next boundary
+                    break;
+                }
+                inPart = true;
+                pastHeaders = false;
+                yamlBuilder.setLength(0);
+                continue;
+            }
+            if (!inPart) continue;
+            if (!pastHeaders) {
+                if (line.isBlank()) {
+                    pastHeaders = true;
+                }
+                continue;
+            }
+            // Collect the content lines
+            if (line.startsWith(boundary.substring(0, 2) + boundary.substring(2).replaceAll("-+$", ""))) {
+                break; // closing boundary
+            }
+            yamlBuilder.append(line).append("\n");
+        }
+
+        var result = yamlBuilder.toString().strip();
+        return result.isBlank() ? bodyStr : result;
+    }
+}

--- a/src/test/java/io/kestra/plugin/git/MockKestraApiServer.java
+++ b/src/test/java/io/kestra/plugin/git/MockKestraApiServer.java
@@ -5,7 +5,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
@@ -179,7 +182,7 @@ public class MockKestraApiServer implements AutoCloseable {
         }
 
         // Deduplicate: keep only the latest revision per (namespace, id)
-        Map<String, FlowWithSource> latest = new java.util.LinkedHashMap<>();
+        Map<String, FlowWithSource> latest = new LinkedHashMap<>();
         for (var f : flows) {
             String key = f.getNamespace() + "." + f.getId();
             FlowWithSource existing = latest.get(key);
@@ -187,7 +190,7 @@ public class MockKestraApiServer implements AutoCloseable {
                 latest.put(key, f);
             }
         }
-        flows = new java.util.ArrayList<>(latest.values());
+        flows = new ArrayList<>(latest.values());
 
         var baos = new ByteArrayOutputStream();
         try (var zos = new ZipOutputStream(baos)) {

--- a/src/test/java/io/kestra/plugin/git/MockKestraApiServer.java
+++ b/src/test/java/io/kestra/plugin/git/MockKestraApiServer.java
@@ -379,29 +379,36 @@ public class MockKestraApiServer implements AutoCloseable {
 
         var dashboards = dashboardRepo.findAll(tenantId);
         var match = dashboards.stream().filter(d -> dashboardId.equals(d.getId())).findFirst();
-        if (match.isPresent() && match.get().getSourceCode() != null) {
+        if (match.isPresent()) {
             var d = match.get();
-            var sourceYaml = d.getSourceCode();
-            // Inject updated timestamp into YAML so SyncDashboards.wrapper() can compare without NPE
+            var sourceYaml = d.getSourceCode() != null ? d.getSourceCode()
+                : "id: " + dashboardId + "\ntitle: " + dashboardId + "\n";
+            // Inject updated timestamp so SyncDashboards.wrapper() can compare timestamps without NPE
             if (!sourceYaml.contains("\nupdated:") && !sourceYaml.startsWith("updated:")) {
                 var ts = d.getUpdated() != null ? d.getUpdated().toString() : "1970-01-01T00:00:00Z";
                 sourceYaml = "updated: " + ts + "\n" + sourceYaml;
             }
-            var yaml = sourceYaml.getBytes(StandardCharsets.UTF_8);
-            exchange.getResponseHeaders().set("Content-Type", "application/x-yaml");
-            exchange.sendResponseHeaders(200, yaml.length);
-            exchange.getResponseBody().write(yaml);
-        } else if (match.isPresent()) {
-            // If no source code in memory, generate minimal YAML with a non-null updated timestamp
-            var updated = match.get().getUpdated() != null ? match.get().getUpdated().toString() : "1970-01-01T00:00:00Z";
-            var yaml = ("id: " + dashboardId + "\ntitle: " + dashboardId + "\nupdated: " + updated + "\n").getBytes(StandardCharsets.UTF_8);
-            exchange.getResponseHeaders().set("Content-Type", "application/x-yaml");
-            exchange.sendResponseHeaders(200, yaml.length);
-            exchange.getResponseBody().write(yaml);
+
+            var accept = exchange.getRequestHeaders().getFirst("Accept");
+            if (accept != null && accept.contains("application/json")) {
+                // Production code calls invokeAPI with Accept: application/json and reads response.get("sourceCode")
+                try {
+                    String json = JacksonMapper.ofJson().writeValueAsString(Map.of("id", d.getId(), "sourceCode", sourceYaml));
+                    sendJson(exchange, 200, json);
+                } catch (Exception e) {
+                    sendJson(exchange, 500, "{\"error\":\"serialization failed\"}");
+                }
+            } else {
+                var yaml = sourceYaml.getBytes(StandardCharsets.UTF_8);
+                exchange.getResponseHeaders().set("Content-Type", "application/x-yaml");
+                exchange.sendResponseHeaders(200, yaml.length);
+                exchange.getResponseBody().write(yaml);
+                exchange.close();
+            }
         } else {
             exchange.sendResponseHeaders(404, -1);
+            exchange.close();
         }
-        exchange.close();
     }
 
     /**

--- a/src/test/java/io/kestra/plugin/git/MockKestraApiServer.java
+++ b/src/test/java/io/kestra/plugin/git/MockKestraApiServer.java
@@ -30,10 +30,13 @@ import io.kestra.core.tenant.TenantService;
  */
 public class MockKestraApiServer implements AutoCloseable {
 
-    private static final Pattern NAMESPACE_FILTER_PATTERN = Pattern.compile("NAMESPACE,[^,]+,(.+?)(?:&|$)");
-    private static final Pattern ID_FILTER_PATTERN = Pattern.compile("ID,[^,]+,(.+?)(?:&|$)");
+    // SDK serializes QueryFilter as filters[namespace][EQUALS]=... or filters[namespace][STARTS_WITH]=...
+    private static final Pattern NS_EQUALS_PATTERN = Pattern.compile("[&?]?filters%5Bnamespace%5D%5BEQUALS%5D=([^&]+)");
+    private static final Pattern NS_STARTS_WITH_PATTERN = Pattern.compile("[&?]?filters%5Bnamespace%5D%5BSTARTS_WITH%5D=([^&]+)");
+    private static final Pattern ID_EQUALS_PATTERN = Pattern.compile("[&?]?filters%5Bid%5D%5BEQUALS%5D=([^&]+)");
     private static final Pattern FLOW_ID_PATTERN = Pattern.compile("(?m)^id:\\s*(.+)$");
     private static final Pattern FLOW_NS_PATTERN = Pattern.compile("(?m)^namespace:\\s*(.+)$");
+    private static final Pattern FLOW_REVISION_PATTERN = Pattern.compile("(?m)^revision:\\s*(.+)$");
     // Matches multipart boundary lines to extract file content
     private static final Pattern MULTIPART_BOUNDARY_PATTERN = Pattern.compile("boundary=([^\\r\\n;]+)");
 
@@ -123,28 +126,33 @@ public class MockKestraApiServer implements AutoCloseable {
     // ---- flow handlers -------------------------------------------------------
 
     /**
-     * GET /api/v1/{tenantId}/flows/export/by-query?filters=NAMESPACE,EQUALS,...
+     * GET /api/v1/{tenantId}/flows/export/by-query?filters%5Bnamespace%5D%5BEQUALS%5D=...
      * Returns a ZIP archive of flow YAML files from the in-memory repo.
+     * The SDK serializes QueryFilter as filters[field][OP]=value (URL-encoded brackets).
      */
     private void handleExportFlows(HttpExchange exchange) throws IOException {
-        var query = exchange.getRequestURI().getRawQuery();
+        var rawQuery = exchange.getRequestURI().getRawQuery();
         var tenantId = extractTenantId(exchange.getRequestURI().getPath(), "flows");
 
-        // Parse namespace filter (EQUALS or STARTS_WITH)
+        // Parse namespace filter: SDK sends filters[namespace][EQUALS]=... or filters[namespace][STARTS_WITH]=...
+        // The brackets are URL-encoded as %5B and %5D
         String namespace = null;
         boolean startsWithMode = false;
-        if (query != null) {
-            Matcher nsMatcher = Pattern.compile("NAMESPACE,([^,]+),([^&]+)").matcher(query);
-            if (nsMatcher.find()) {
-                startsWithMode = "STARTS_WITH".equals(decode(nsMatcher.group(1)));
-                namespace = decode(nsMatcher.group(2));
+        if (rawQuery != null) {
+            Matcher nsEqMatcher = NS_EQUALS_PATTERN.matcher(rawQuery);
+            Matcher nsSwMatcher = NS_STARTS_WITH_PATTERN.matcher(rawQuery);
+            if (nsSwMatcher.find()) {
+                startsWithMode = true;
+                namespace = decode(nsSwMatcher.group(1));
+            } else if (nsEqMatcher.find()) {
+                namespace = decode(nsEqMatcher.group(1));
             }
         }
 
-        // Parse optional ID filter
+        // Parse optional ID filter: filters[id][EQUALS]=...
         String flowIdFilter = null;
-        if (query != null) {
-            Matcher idMatcher = Pattern.compile("ID,[^,]+,([^&]+)").matcher(query);
+        if (rawQuery != null) {
+            Matcher idMatcher = ID_EQUALS_PATTERN.matcher(rawQuery);
             if (idMatcher.find()) {
                 flowIdFilter = decode(idMatcher.group(1));
             }
@@ -157,10 +165,7 @@ public class MockKestraApiServer implements AutoCloseable {
 
         List<FlowWithSource> flows;
         if (namespace == null || namespace.isBlank()) {
-            flows = flowRepo.findAllForAllTenants().stream()
-                .filter(f -> f instanceof FlowWithSource)
-                .map(f -> (FlowWithSource) f)
-                .toList();
+            flows = flowRepo.findAllWithSourceForAllTenants();
         } else if (startsWithMode) {
             flows = flowRepo.findByNamespacePrefixWithSource(tenantId, namespace);
         } else {
@@ -178,8 +183,12 @@ public class MockKestraApiServer implements AutoCloseable {
             for (var f : flows) {
                 var source = f.getSource();
                 if (source == null || source.isBlank()) {
-                    // Build a minimal YAML from the flow model
-                    source = "id: " + f.getId() + "\nnamespace: " + f.getNamespace() + "\n";
+                    // Build a minimal YAML with revision so the parsed flow has a non-null revision
+                    source = "id: " + f.getId() + "\nnamespace: " + f.getNamespace()
+                        + "\nrevision: " + (f.getRevision() != null ? f.getRevision() : 1) + "\n";
+                } else if (!FLOW_REVISION_PATTERN.matcher(source).find() && f.getRevision() != null) {
+                    // Inject revision into the source YAML when it's missing
+                    source = "revision: " + f.getRevision() + "\n" + source;
                 }
                 var bytes = source.getBytes(StandardCharsets.UTF_8);
                 zos.putNextEntry(new ZipEntry(f.getNamespace() + "." + f.getId() + ".yml"));
@@ -328,7 +337,11 @@ public class MockKestraApiServer implements AutoCloseable {
         for (int i = 0; i < dashboards.size(); i++) {
             var d = dashboards.get(i);
             if (i > 0) sb.append(",");
-            sb.append("{\"id\":\"").append(d.getId()).append("\",\"title\":\"").append(d.getId()).append("\"}");
+            // Include a non-null updated timestamp so production code can compare revisions
+            var updatedTs = d.getUpdated() != null ? d.getUpdated().toString() : "1970-01-01T00:00:00Z";
+            sb.append("{\"id\":\"").append(d.getId())
+              .append("\",\"title\":\"").append(d.getId())
+              .append("\",\"updated\":\"").append(updatedTs).append("\"}");
         }
         sb.append("],\"total\":").append(dashboards.size()).append("}");
         sendJson(exchange, 200, sb.toString());
@@ -349,8 +362,9 @@ public class MockKestraApiServer implements AutoCloseable {
             exchange.sendResponseHeaders(200, yaml.length);
             exchange.getResponseBody().write(yaml);
         } else if (match.isPresent()) {
-            // If no source code in memory, generate minimal YAML
-            var yaml = ("id: " + dashboardId + "\ntitle: " + dashboardId + "\n").getBytes(StandardCharsets.UTF_8);
+            // If no source code in memory, generate minimal YAML with a non-null updated timestamp
+            var updated = match.get().getUpdated() != null ? match.get().getUpdated().toString() : "1970-01-01T00:00:00Z";
+            var yaml = ("id: " + dashboardId + "\ntitle: " + dashboardId + "\nupdated: " + updated + "\n").getBytes(StandardCharsets.UTF_8);
             exchange.getResponseHeaders().set("Content-Type", "application/x-yaml");
             exchange.sendResponseHeaders(200, yaml.length);
             exchange.getResponseBody().write(yaml);

--- a/src/test/java/io/kestra/plugin/git/NamespaceSyncTest.java
+++ b/src/test/java/io/kestra/plugin/git/NamespaceSyncTest.java
@@ -20,6 +20,7 @@ import io.kestra.core.models.flows.FlowWithSource;
 import io.kestra.core.models.flows.GenericFlow;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.repositories.FlowRepositoryInterface;
+import io.kestra.core.runners.DefaultRunContext;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.serializers.JacksonMapper;
@@ -190,7 +191,9 @@ public class NamespaceSyncTest extends AbstractGitTest {
                 "gitDirectory", GIT_DIRECTORY
             )
         );
-        return runContextFactory.of(ctx);
+        var rc = runContextFactory.of(ctx);
+        runContextFactory.initializer().forExecutor((DefaultRunContext) rc);
+        return rc;
     }
 
     private void createFlowInKestra(String id, String namespace) {

--- a/src/test/java/io/kestra/plugin/git/NamespaceSyncTest.java
+++ b/src/test/java/io/kestra/plugin/git/NamespaceSyncTest.java
@@ -1,6 +1,7 @@
 package io.kestra.plugin.git;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
@@ -9,6 +10,7 @@ import java.nio.file.Path;
 import java.util.*;
 
 import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -52,6 +54,18 @@ public class NamespaceSyncTest extends AbstractGitTest {
     @Inject
     private StorageInterface storageInterface;
 
+    private MockKestraApiServer server;
+
+    @BeforeEach
+    void startMockServer() throws IOException {
+        server = MockKestraApiServer.start(flowRepository);
+    }
+
+    @AfterEach
+    void stopMockServer() {
+        server.close();
+    }
+
     @BeforeEach
     void initBranch() {
         branch = BRANCH_PREFIX + "-" + Long.toHexString(System.nanoTime());
@@ -87,6 +101,7 @@ public class NamespaceSyncTest extends AbstractGitTest {
             .sourceOfTruth(Property.ofValue(NamespaceSync.SourceOfTruth.KESTRA))
             .whenMissingInSource(Property.ofValue(NamespaceSync.WhenMissingInSource.KEEP))
             .dryRun(Property.ofValue(true))
+            .kestraUrl(Property.ofValue(server.url()))
             .build();
 
         NamespaceSync.Output out = task.run(rc);
@@ -118,6 +133,7 @@ public class NamespaceSyncTest extends AbstractGitTest {
             .sourceOfTruth(Property.ofValue(NamespaceSync.SourceOfTruth.KESTRA))
             .whenMissingInSource(Property.ofValue(NamespaceSync.WhenMissingInSource.KEEP))
             .dryRun(Property.ofValue(false))
+            .kestraUrl(Property.ofValue(server.url()))
             .build();
 
         NamespaceSync.Output out = task.run(rc);
@@ -167,6 +183,7 @@ public class NamespaceSyncTest extends AbstractGitTest {
             .sourceOfTruth(Property.ofValue(NamespaceSync.SourceOfTruth.GIT))
             .whenMissingInSource(Property.ofValue(NamespaceSync.WhenMissingInSource.KEEP))
             .dryRun(Property.ofValue(false))
+            .kestraUrl(Property.ofValue(server.url()))
             .build();
 
         task.run(rc);
@@ -228,6 +245,7 @@ public class NamespaceSyncTest extends AbstractGitTest {
             .sourceOfTruth(Property.ofValue(NamespaceSync.SourceOfTruth.KESTRA))
             .whenMissingInSource(Property.ofValue(NamespaceSync.WhenMissingInSource.DELETE))
             .dryRun(Property.ofValue(false))
+            .kestraUrl(Property.ofValue(server.url()))
             .build();
         push.run(rc);
     }

--- a/src/test/java/io/kestra/plugin/git/NamespaceSyncTest.java
+++ b/src/test/java/io/kestra/plugin/git/NamespaceSyncTest.java
@@ -200,7 +200,7 @@ public class NamespaceSyncTest extends AbstractGitTest {
 
             tasks:
               - id: say
-                type: io.kestra.core.tasks.log.Log
+                type: io.kestra.plugin.core.log.Log
                 message: hello
             """.formatted(id, namespace);
         GenericFlow f = GenericFlow.fromYaml(TENANT_ID, src);

--- a/src/test/java/io/kestra/plugin/git/PushDahboardsTest.java
+++ b/src/test/java/io/kestra/plugin/git/PushDahboardsTest.java
@@ -14,6 +14,8 @@ import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.transport.RefSpec;
 import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.kestra.core.junit.annotations.KestraTest;
@@ -43,6 +45,18 @@ public class PushDahboardsTest extends AbstractGitTest {
     @Inject
     private DashboardRepositoryInterface dashboardRepositoryInterface;
 
+    private MockKestraApiServer server;
+
+    @BeforeEach
+    void startMockServer() throws IOException {
+        server = MockKestraApiServer.start(dashboardRepositoryInterface);
+    }
+
+    @AfterEach
+    void stopMockServer() {
+        server.close();
+    }
+
     @Test
     void defaultCase_DefaultRegex() throws Exception {
         String tenantId = TenantService.MAIN_TENANT;
@@ -71,6 +85,7 @@ public class PushDahboardsTest extends AbstractGitTest {
                 .password(Property.ofExpression("{{pat}}"))
                 .authorEmail(Property.ofExpression("{{email}}"))
                 .authorName(Property.ofExpression("{{name}}"))
+                .kestraUrl(Property.ofValue(server.url()))
                 .build();
 
             PushDashboards.Output pushDashboardsOutput = pushDashboards.run(runContext);
@@ -144,6 +159,7 @@ public class PushDahboardsTest extends AbstractGitTest {
                 .dashboards("first*")
                 .authorEmail(Property.ofExpression("{{email}}"))
                 .authorName(Property.ofExpression("{{name}}"))
+                .kestraUrl(Property.ofValue(server.url()))
                 .build();
 
             pushDashboards.run(runContext);

--- a/src/test/java/io/kestra/plugin/git/PushDahboardsTest.java
+++ b/src/test/java/io/kestra/plugin/git/PushDahboardsTest.java
@@ -20,6 +20,7 @@ import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.dashboards.Dashboard;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.repositories.DashboardRepositoryInterface;
+import io.kestra.core.runners.DefaultRunContext;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.tenant.TenantService;
@@ -202,7 +203,9 @@ public class PushDahboardsTest extends AbstractGitTest {
                 }
             }
         }
-        return runContextFactory.of(map);
+        var rc = runContextFactory.of(map);
+        runContextFactory.initializer().forExecutor((DefaultRunContext) rc);
+        return rc;
     }
 
     private static RevCommit assertIsLastCommit(RunContext cloneRunContext, PushDashboards.Output pushOutput) throws IOException, GitAPIException {

--- a/src/test/java/io/kestra/plugin/git/PushDashboardsContainerTest.java
+++ b/src/test/java/io/kestra/plugin/git/PushDashboardsContainerTest.java
@@ -53,39 +53,43 @@ public class PushDashboardsContainerTest extends AbstractKestraContainerTest {
         var dashboardId = "push-container-test-" + IdUtils.create().toLowerCase();
         var runContext = buildRunContext();
 
-        var dashboardYaml = "id: " + dashboardId + "\n"
-            + "title: Container Test Dashboard\n"
-            + "description: Created by PushDashboardsContainerTest\n"
-            + "timeWindow:\n"
-            + "  default: P30D\n"
-            + "  max: P365D\n"
-            + "charts:\n"
-            + "  - id: executions_timeseries\n"
-            + "    type: io.kestra.plugin.core.dashboard.chart.TimeSeries\n"
-            + "    chartOptions:\n"
-            + "      displayName: Executions\n"
-            + "      description: Executions duration and count per date\n"
-            + "      legend:\n"
-            + "        enabled: true\n"
-            + "      column: date\n"
-            + "      colorByColumn: state\n"
-            + "    data:\n"
-            + "      type: io.kestra.plugin.core.dashboard.data.Executions\n"
-            + "      columns:\n"
-            + "        date:\n"
-            + "          field: START_DATE\n"
-            + "          displayName: Date\n"
-            + "        state:\n"
-            + "          field: STATE\n"
-            + "        total:\n"
-            + "          displayName: Executions\n"
-            + "          agg: COUNT\n"
-            + "          graphStyle: BARS\n"
-            + "        duration:\n"
-            + "          displayName: Duration\n"
-            + "          field: DURATION\n"
-            + "          agg: SUM\n"
-            + "          graphStyle: LINES\n";
+        var dashboardYaml = """
+            id: \
+            """ + dashboardId + """
+
+            title: Container Test Dashboard
+            description: Created by PushDashboardsContainerTest
+            timeWindow:
+              default: P30D
+              max: P365D
+            charts:
+              - id: executions_timeseries
+                type: io.kestra.plugin.core.dashboard.chart.TimeSeries
+                chartOptions:
+                  displayName: Executions
+                  description: Executions duration and count per date
+                  legend:
+                    enabled: true
+                  column: date
+                  colorByColumn: state
+                data:
+                  type: io.kestra.plugin.core.dashboard.data.Executions
+                  columns:
+                    date:
+                      field: START_DATE
+                      displayName: Date
+                    state:
+                      field: STATE
+                    total:
+                      displayName: Executions
+                      agg: COUNT
+                      graphStyle: BARS
+                    duration:
+                      displayName: Duration
+                      field: DURATION
+                      agg: SUM
+                      graphStyle: LINES
+            """;
 
         kestraTestDataUtils.createDashboard(TENANT_ID, dashboardYaml);
 

--- a/src/test/java/io/kestra/plugin/git/PushDashboardsContainerTest.java
+++ b/src/test/java/io/kestra/plugin/git/PushDashboardsContainerTest.java
@@ -1,0 +1,142 @@
+package io.kestra.plugin.git;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.transport.RefSpec;
+import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.DefaultRunContext;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.utils.IdUtils;
+import io.micronaut.context.annotation.Value;
+
+import jakarta.inject.Inject;
+
+import static org.eclipse.jgit.lib.Constants.R_HEADS;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * Integration test for {@link PushDashboards} against a live Kestra container and a real GitHub repository.
+ * Validates that {@code apiClient.invokeAPI} correctly authenticates and fetches dashboard YAML
+ * from a secured Kestra endpoint using credentials from the KestraClient's defaultHeaderMap.
+ *
+ * <p>The Kestra container is started once per class by {@link AbstractKestraContainerTest}.
+ * Kestra API credentials are hardcoded for test use only.
+ * GitHub credentials are read from the {@code kestra.git.pat} Micronaut property (set via {@code GH_PERSONAL_TOKEN}).
+ * The remote branch is deleted after each test run to avoid orphan branches.
+ */
+@KestraTest
+@io.micronaut.context.annotation.Property(name = "kestra.tasks.sdk.authentication.username", value = "admin@admin.com")
+@io.micronaut.context.annotation.Property(name = "kestra.tasks.sdk.authentication.password", value = "Root!1234")
+public class PushDashboardsContainerTest extends AbstractKestraContainerTest {
+
+    private static final String REPO_URL = "https://github.com/kestra-io/unit-tests";
+    private static final String GIT_DIRECTORY = "_dashboards";
+
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    @Value("${kestra.git.pat}")
+    private String gitPat;
+
+    @Test
+    void pushDashboardsToGit_shouldProduceCommitUrl() throws Exception {
+        var branch = IdUtils.create();
+        var dashboardId = "push-container-test-" + IdUtils.create().toLowerCase();
+        var runContext = buildRunContext();
+
+        var dashboardYaml = "id: " + dashboardId + "\n"
+            + "title: Container Test Dashboard\n"
+            + "description: Created by PushDashboardsContainerTest\n"
+            + "timeWindow:\n"
+            + "  default: P30D\n"
+            + "  max: P365D\n"
+            + "charts:\n"
+            + "  - id: executions_timeseries\n"
+            + "    type: io.kestra.plugin.core.dashboard.chart.TimeSeries\n"
+            + "    chartOptions:\n"
+            + "      displayName: Executions\n"
+            + "      description: Executions duration and count per date\n"
+            + "      legend:\n"
+            + "        enabled: true\n"
+            + "      column: date\n"
+            + "      colorByColumn: state\n"
+            + "    data:\n"
+            + "      type: io.kestra.plugin.core.dashboard.data.Executions\n"
+            + "      columns:\n"
+            + "        date:\n"
+            + "          field: START_DATE\n"
+            + "          displayName: Date\n"
+            + "        state:\n"
+            + "          field: STATE\n"
+            + "        total:\n"
+            + "          displayName: Executions\n"
+            + "          agg: COUNT\n"
+            + "          graphStyle: BARS\n"
+            + "        duration:\n"
+            + "          displayName: Duration\n"
+            + "          field: DURATION\n"
+            + "          agg: SUM\n"
+            + "          graphStyle: LINES\n";
+
+        kestraTestDataUtils.createDashboard(TENANT_ID, dashboardYaml);
+
+        var task = PushDashboards.builder()
+            .url(Property.ofValue(REPO_URL))
+            .username(Property.ofValue(gitPat))
+            .password(Property.ofValue(gitPat))
+            .branch(Property.ofValue(branch))
+            .gitDirectory(Property.ofValue(GIT_DIRECTORY))
+            .kestraUrl(Property.ofValue(kestraUrl))
+            .build();
+
+        PushDashboards.Output output = task.run(runContext);
+
+        try {
+            assertThat("output must be present", output, notNullValue());
+            assertThat("commitURL must be present", output.getCommitURL(), notNullValue());
+        } finally {
+            var gitDir = runContext.workingDir().path().resolve(".git");
+            if (gitDir.toFile().exists()) {
+                deleteRemoteBranch(runContext, branch);
+            }
+        }
+    }
+
+    private RunContext buildRunContext() {
+        var rc = runContextFactory.of(
+            Map.of(
+                "flow", Map.of(
+                    "tenantId", TENANT_ID,
+                    "namespace", "io.kestra.tests.container.pushdashboards",
+                    "id", "push-dashboards-container-test"
+                )
+            )
+        );
+        runContextFactory.initializer().forExecutor((DefaultRunContext) rc);
+        return rc;
+    }
+
+    private void deleteRemoteBranch(RunContext runContext, String branchName) throws GitAPIException, IOException {
+        try (var git = Git.open(runContext.workingDir().path().toFile())) {
+            git.checkout().setName("tmp").setCreateBranch(true).call();
+            git.branchDelete().setBranchNames(R_HEADS + branchName).call();
+            var refSpec = new RefSpec()
+                .setSource(null)
+                .setDestination(R_HEADS + branchName);
+            git.push()
+                .setCredentialsProvider(new UsernamePasswordCredentialsProvider(gitPat, gitPat))
+                .setRefSpecs(refSpec)
+                .setRemote("origin")
+                .call();
+        }
+    }
+}

--- a/src/test/java/io/kestra/plugin/git/PushDashboardsTest.java
+++ b/src/test/java/io/kestra/plugin/git/PushDashboardsTest.java
@@ -36,7 +36,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
 @KestraTest
-public class PushDahboardsTest extends AbstractGitTest {
+public class PushDashboardsTest extends AbstractGitTest {
     public static final String DESCRIPTION = "One-task push";
 
     @Inject
@@ -75,7 +75,7 @@ public class PushDahboardsTest extends AbstractGitTest {
 
         try {
             PushDashboards pushDashboards = PushDashboards.builder()
-                .id(PushDahboardsTest.class.getSimpleName())
+                .id(PushDashboardsTest.class.getSimpleName())
                 .type(PushDashboards.class.getName())
                 .branch(Property.ofExpression("{{branch}}"))
                 .url(Property.ofExpression("{{url}}"))
@@ -148,7 +148,7 @@ public class PushDahboardsTest extends AbstractGitTest {
 
         try {
             PushDashboards pushDashboards = PushDashboards.builder()
-                .id(PushDahboardsTest.class.getSimpleName())
+                .id(PushDashboardsTest.class.getSimpleName())
                 .type(PushDashboards.class.getName())
                 .branch(Property.ofExpression("{{branch}}"))
                 .url(Property.ofExpression("{{url}}"))
@@ -198,7 +198,8 @@ public class PushDahboardsTest extends AbstractGitTest {
             Map.of(
                 "flow", Map.of(
                     "tenantId", tenantId,
-                    "namespace", "system"
+                    "namespace", "system",
+                    "id", "PushDashboardsTest"
                 ),
                 "url", url,
                 "description", DESCRIPTION,

--- a/src/test/java/io/kestra/plugin/git/PushFlowsContainerTest.java
+++ b/src/test/java/io/kestra/plugin/git/PushFlowsContainerTest.java
@@ -1,0 +1,124 @@
+package io.kestra.plugin.git;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.transport.RefSpec;
+import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.DefaultRunContext;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.utils.IdUtils;
+import io.micronaut.context.annotation.Value;
+
+import jakarta.inject.Inject;
+
+import static org.eclipse.jgit.lib.Constants.R_HEADS;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * Integration test for {@link PushFlows} against a live Kestra container and a real GitHub repository.
+ * Complements (does not replace) the unit-level {@link PushFlowsTest} mock-server tests.
+ *
+ * <p>The Kestra container is started once per class by {@link AbstractKestraContainerTest}.
+ * Kestra API credentials are hardcoded for test use only.
+ * GitHub credentials are read from the {@code kestra.git.pat} Micronaut property (set via {@code GH_PERSONAL_TOKEN}).
+ * The remote branch is deleted after each test run to avoid orphan branches.
+ */
+@KestraTest
+@io.micronaut.context.annotation.Property(name = "kestra.tasks.sdk.authentication.username", value = "admin@admin.com")
+@io.micronaut.context.annotation.Property(name = "kestra.tasks.sdk.authentication.password", value = "Root!1234")
+public class PushFlowsContainerTest extends AbstractKestraContainerTest {
+
+    private static final String REPO_URL = "https://github.com/kestra-io/unit-tests";
+    private static final String GIT_DIRECTORY = "my-flows";
+
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    @Value("${kestra.git.pat}")
+    private String gitPat;
+
+    @Test
+    void pushFlowsToGit_shouldProduceCommitUrl() throws Exception {
+        var sourceNamespace = "io.kestra.tests.container.pushflows." + IdUtils.create().toLowerCase();
+        var branch = IdUtils.create();
+        var runContext = buildRunContext(sourceNamespace);
+
+        var flowYaml = """
+            id: push-flows-container-test-flow
+            namespace: \
+            """ + sourceNamespace + """
+
+            tasks:
+              - id: log
+                type: io.kestra.plugin.core.log.Log
+                message: Hello from container test
+            """;
+
+        kestraTestDataUtils.createFlow(TENANT_ID, flowYaml);
+
+        var task = PushFlows.builder()
+            .url(Property.ofValue(REPO_URL))
+            .username(Property.ofValue(gitPat))
+            .password(Property.ofValue(gitPat))
+            .branch(Property.ofValue(branch))
+            .gitDirectory(Property.ofValue(GIT_DIRECTORY))
+            .sourceNamespace(Property.ofValue(sourceNamespace))
+            .kestraUrl(Property.ofValue(kestraUrl))
+            .build();
+
+        PushFlows.Output output = task.run(runContext);
+
+        try {
+            assertThat("output must be present", output, notNullValue());
+            assertThat("commitURL must be present", output.getCommitURL(), notNullValue());
+        } finally {
+            // Only delete the remote branch if a git repo was actually cloned (i.e., the push succeeded at least partially)
+            var gitDir = runContext.workingDir().path().resolve(".git");
+            if (gitDir.toFile().exists()) {
+                deleteRemoteBranch(runContext, branch);
+            }
+        }
+    }
+
+    private RunContext buildRunContext(String sourceNamespace) {
+        var rc = runContextFactory.of(
+            Map.of(
+                "flow", Map.of(
+                    "tenantId", "main",
+                    "namespace", sourceNamespace,
+                    "id", "push-flows-container-test"
+                )
+            )
+        );
+        runContextFactory.initializer().forExecutor((DefaultRunContext) rc);
+        return rc;
+    }
+
+    /**
+     * Deletes the remote branch created during the test to avoid leaving orphan branches in the repository.
+     * Mirrors the pattern used in {@link PushFlowsTest}.
+     */
+    private void deleteRemoteBranch(RunContext runContext, String branchName) throws GitAPIException, IOException {
+        try (var git = Git.open(runContext.workingDir().path().toFile())) {
+            git.checkout().setName("tmp").setCreateBranch(true).call();
+            git.branchDelete().setBranchNames(R_HEADS + branchName).call();
+            var refSpec = new RefSpec()
+                .setSource(null)
+                .setDestination(R_HEADS + branchName);
+            git.push()
+                .setCredentialsProvider(new UsernamePasswordCredentialsProvider(gitPat, gitPat))
+                .setRefSpecs(refSpec)
+                .setRemote("origin")
+                .call();
+        }
+    }
+}

--- a/src/test/java/io/kestra/plugin/git/PushFlowsTest.java
+++ b/src/test/java/io/kestra/plugin/git/PushFlowsTest.java
@@ -28,6 +28,7 @@ import io.kestra.core.models.flows.FlowWithSource;
 import io.kestra.core.models.flows.GenericFlow;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.repositories.FlowRepositoryInterface;
+import io.kestra.core.runners.DefaultRunContext;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.serializers.JacksonMapper;
@@ -762,7 +763,9 @@ public class PushFlowsTest extends AbstractGitTest {
                 }
             }
         }
-        return runContextFactory.of(map);
+        var rc = runContextFactory.of(map);
+        runContextFactory.initializer().forExecutor((DefaultRunContext) rc);
+        return rc;
     }
 
     private static RevCommit assertIsLastCommit(RunContext cloneRunContext, PushFlows.Output pushOutput) throws IOException, GitAPIException {

--- a/src/test/java/io/kestra/plugin/git/PushFlowsTest.java
+++ b/src/test/java/io/kestra/plugin/git/PushFlowsTest.java
@@ -17,6 +17,8 @@ import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.transport.RefSpec;
 import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -53,6 +55,18 @@ public class PushFlowsTest extends AbstractGitTest {
     @Inject
     private FlowRepositoryInterface flowRepositoryInterface;
 
+    private MockKestraApiServer server;
+
+    @BeforeEach
+    void startMockServer() throws IOException {
+        server = MockKestraApiServer.start(flowRepositoryInterface);
+    }
+
+    @AfterEach
+    void stopMockServer() {
+        server.close();
+    }
+
     @Test
     void defaultCase_SingleRegex() throws Exception {
         String tenantId = TenantService.MAIN_TENANT;
@@ -82,6 +96,7 @@ public class PushFlowsTest extends AbstractGitTest {
             .flows("second*")
             .includeChildNamespaces(Property.ofValue(true))
             .gitDirectory(Property.ofExpression("{{gitDirectory}}"))
+            .kestraUrl(Property.ofValue(server.url()))
             .build();
 
         try {
@@ -155,6 +170,7 @@ public class PushFlowsTest extends AbstractGitTest {
             .flows("second*")
             .includeChildNamespaces(Property.ofValue(true))
             .gitDirectory(Property.ofExpression("{{gitDirectory}}"))
+            .kestraUrl(Property.ofValue(server.url()))
             .build();
 
         try {
@@ -221,6 +237,7 @@ public class PushFlowsTest extends AbstractGitTest {
             .includeChildNamespaces(Property.ofValue(true))
             .gitDirectory(Property.ofExpression("{{gitDirectory}}"))
             .dryRun(Property.ofValue(true))
+            .kestraUrl(Property.ofValue(server.url()))
             .build();
 
         PushFlows.Output pushOutput = pushFlows.run(runContext);
@@ -268,6 +285,7 @@ public class PushFlowsTest extends AbstractGitTest {
             .targetNamespace(Property.ofExpression("{{targetNamespace}}"))
             .includeChildNamespaces(Property.ofValue(true))
             .gitDirectory(Property.ofExpression("{{gitDirectory}}"))
+            .kestraUrl(Property.ofValue(server.url()))
             .build();
 
         try {
@@ -369,6 +387,7 @@ public class PushFlowsTest extends AbstractGitTest {
             .targetNamespace(Property.ofExpression("{{targetNamespace}}"))
             .includeChildNamespaces(Property.ofValue(true))
             .gitDirectory(Property.ofExpression("{{gitDirectory}}"))
+            .kestraUrl(Property.ofValue(server.url()))
             .build();
 
         try {
@@ -451,6 +470,7 @@ public class PushFlowsTest extends AbstractGitTest {
             .flows(useStringPebbleArray ? "{{ flows }}" : List.of("{{ flow1 }}", "{{ flow2 }}"))
             .includeChildNamespaces(Property.ofValue(true))
             .gitDirectory(Property.ofExpression("{{gitDirectory}}"))
+            .kestraUrl(Property.ofValue(server.url()))
             .build();
 
         try {
@@ -526,6 +546,7 @@ public class PushFlowsTest extends AbstractGitTest {
             .sourceNamespace(Property.ofExpression("{{sourceNamespace}}"))
             .targetNamespace(Property.ofExpression("{{targetNamespace}}"))
             .gitDirectory(Property.ofExpression("{{gitDirectory}}"))
+            .kestraUrl(Property.ofValue(server.url()))
             .build();
 
         try {
@@ -590,6 +611,7 @@ public class PushFlowsTest extends AbstractGitTest {
             .targetNamespace(Property.ofExpression("{{targetNamespace}}"))
             .includeChildNamespaces(Property.ofValue(true))
             .gitDirectory(Property.ofExpression("{{gitDirectory}}"))
+            .kestraUrl(Property.ofValue(server.url()))
             .build();
 
         try {
@@ -643,6 +665,7 @@ public class PushFlowsTest extends AbstractGitTest {
                 .targetNamespace(Property.ofExpression("{{targetNamespace}}"))
                 .gitDirectory(Property.ofExpression("{{gitDirectory}}"))
                 .delete(Property.ofValue(false))
+                .kestraUrl(Property.ofValue(server.url()))
                 .build();
 
             PushFlows.Output firstOutput = firstPush.run(runContext1);
@@ -681,6 +704,7 @@ public class PushFlowsTest extends AbstractGitTest {
                 .targetNamespace(Property.ofExpression("{{targetNamespace}}"))
                 .gitDirectory(Property.ofExpression("{{gitDirectory}}"))
                 .delete(Property.ofValue(false))
+                .kestraUrl(Property.ofValue(server.url()))
                 .build();
 
             PushFlows.Output secondOutput = secondPush.run(runContext2);
@@ -708,6 +732,7 @@ public class PushFlowsTest extends AbstractGitTest {
                 .targetNamespace(Property.ofExpression("{{targetNamespace}}"))
                 .gitDirectory(Property.ofExpression("{{gitDirectory}}"))
                 .delete(Property.ofValue(true))
+                .kestraUrl(Property.ofValue(server.url()))
                 .build();
 
             PushFlows.Output thirdOutput = thirdPush.run(runContext3);

--- a/src/test/java/io/kestra/plugin/git/PushFlowsTest.java
+++ b/src/test/java/io/kestra/plugin/git/PushFlowsTest.java
@@ -821,10 +821,10 @@ public class PushFlowsTest extends AbstractGitTest {
 
             tasks:
               - id: my-task
-                type: io.kestra.core.tasks.log.Log
+                type: io.kestra.plugin.core.log.Log
                 message: Hello from my-task
               - id: subflow
-                type: io.kestra.core.tasks.flows.Subflow
+                type: io.kestra.plugin.core.flow.Subflow
                 namespace:\s""" + namespace + """
             .sub-namespace
                 flowId: another-flow

--- a/src/test/java/io/kestra/plugin/git/PushTest.java
+++ b/src/test/java/io/kestra/plugin/git/PushTest.java
@@ -629,7 +629,7 @@ class PushTest extends AbstractGitTest {
 
             tasks:
               - id: my-task
-                type: io.kestra.core.tasks.log.Log
+                type: io.kestra.plugin.core.log.Log
                 message: Hello from my-task""";
         return flowRepositoryInterface.create(
             GenericFlow.fromYaml(tenantId, flowSource)

--- a/src/test/java/io/kestra/plugin/git/PushTest.java
+++ b/src/test/java/io/kestra/plugin/git/PushTest.java
@@ -24,6 +24,7 @@ import io.kestra.core.models.flows.GenericFlow;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.NamespaceFiles;
 import io.kestra.core.repositories.FlowRepositoryInterface;
+import io.kestra.core.runners.DefaultRunContext;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.tenant.TenantService;
@@ -60,6 +61,7 @@ class PushTest extends AbstractGitTest {
             .build();
 
         RunContext cloneRunContext = runContextFactory.of();
+        runContextFactory.initializer().forExecutor((DefaultRunContext) cloneRunContext);
         clone.run(cloneRunContext);
 
         File extraFile = cloneRunContext.workingDir().resolve(Path.of("some_file.txt")).toFile();
@@ -138,6 +140,7 @@ class PushTest extends AbstractGitTest {
             .build();
 
         RunContext cloneRunContext = runContextFactory.of();
+        runContextFactory.initializer().forExecutor((DefaultRunContext) cloneRunContext);
         clone.run(cloneRunContext);
         String ciBranchExpectedLastCommitId = getLastCommitId(cloneRunContext);
 
@@ -181,6 +184,7 @@ class PushTest extends AbstractGitTest {
                 "description", "One-task push"
             )
         );
+        runContextFactory.initializer().forExecutor((DefaultRunContext) runContext);
 
         String expectedInputFileContent = IdUtils.create();
         String expectedNamespaceFileContent = IdUtils.create();
@@ -289,7 +293,9 @@ class PushTest extends AbstractGitTest {
             .password(Property.ofValue(pat))
             .branch(Property.ofValue(branchName))
             .build();
-        push.run(runContextFactory.of());
+        var rc1 = runContextFactory.of();
+        runContextFactory.initializer().forExecutor((DefaultRunContext) rc1);
+        push.run(rc1);
 
         RunContext runContext = runContextFactory.of();
         clone.run(runContext);
@@ -298,7 +304,9 @@ class PushTest extends AbstractGitTest {
         push = push.toBuilder()
             .inputFiles(null)
             .build();
-        push.run(runContextFactory.of());
+        var rc2 = runContextFactory.of();
+        runContextFactory.initializer().forExecutor((DefaultRunContext) rc2);
+        push.run(rc2);
 
         runContext = runContextFactory.of();
         try {
@@ -342,10 +350,13 @@ class PushTest extends AbstractGitTest {
             .branch(Property.ofValue(branchName))
             .build();
         RunContext runContext = runContextFactory.of();
+        runContextFactory.initializer().forExecutor((DefaultRunContext) runContext);
         Push.Output firstPush = push.run(runContext);
 
         try {
-            Push.Output run = push.run(runContextFactory.of());
+            var rc3 = runContextFactory.of();
+            runContextFactory.initializer().forExecutor((DefaultRunContext) rc3);
+            Push.Output run = push.run(rc3);
             assertThat(run.getCommitId(), nullValue());
 
             runContext = runContextFactory.of();
@@ -369,6 +380,7 @@ class PushTest extends AbstractGitTest {
     void oneTaskPush_WithSpecifiedDirectory() throws Exception {
         String branchName = IdUtils.create();
         RunContext runContext = runContextFactory.of();
+        runContextFactory.initializer().forExecutor((DefaultRunContext) runContext);
 
         String expectedInputFileContent = IdUtils.create();
         String expectedNestedInputFileContent = IdUtils.create();
@@ -438,6 +450,7 @@ class PushTest extends AbstractGitTest {
                 "description", "One-task push"
             )
         );
+        runContextFactory.initializer().forExecutor((DefaultRunContext) runContext);
 
         FlowWithSource createdFlow = this.createFlow(tenantId, namespace);
         FlowWithSource createdSubNsFlow = this.createFlow(tenantId, namespace + ".sub-namespace");
@@ -494,6 +507,7 @@ class PushTest extends AbstractGitTest {
                 "description", "One-task push"
             )
         );
+        runContextFactory.initializer().forExecutor((DefaultRunContext) runContext);
 
         FlowWithSource createdFlow = this.createFlow(tenantId, namespace);
         FlowWithSource createdSubNsFlow = this.createFlow(tenantId, namespace + ".sub-namespace");
@@ -559,6 +573,7 @@ class PushTest extends AbstractGitTest {
                 "description", "One-task push"
             )
         );
+        runContextFactory.initializer().forExecutor((DefaultRunContext) runContext);
 
         FlowWithSource createdFlow = this.createFlow(tenantId, namespace);
         FlowWithSource createdSubNsFlow = this.createFlow(tenantId, namespace + ".sub-namespace");

--- a/src/test/java/io/kestra/plugin/git/PushTest.java
+++ b/src/test/java/io/kestra/plugin/git/PushTest.java
@@ -15,7 +15,9 @@ import org.eclipse.jgit.api.errors.TransportException;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.transport.RefSpec;
 import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.kestra.core.junit.annotations.KestraTest;
@@ -47,6 +49,18 @@ class PushTest extends AbstractGitTest {
 
     @Inject
     private FlowRepositoryInterface flowRepositoryInterface;
+
+    private MockKestraApiServer server;
+
+    @BeforeEach
+    void startMockServer() throws IOException {
+        server = MockKestraApiServer.start(flowRepositoryInterface);
+    }
+
+    @AfterEach
+    void stopMockServer() {
+        server.close();
+    }
 
     @Test
     void cloneThenPush_OnlyNeedsCredentialsForPush() throws Exception {
@@ -90,6 +104,7 @@ class PushTest extends AbstractGitTest {
             .username(Property.ofValue(pat))
             .password(Property.ofValue(pat))
             .branch(Property.ofValue(branchName))
+            .kestraUrl(Property.ofValue(server.url()))
             .build();
         Push.Output pushOutput = push.run(cloneRunContext);
 
@@ -157,6 +172,7 @@ class PushTest extends AbstractGitTest {
             .username(Property.ofValue(pat))
             .password(Property.ofValue(pat))
             .branch(Property.ofValue(otherBranch))
+            .kestraUrl(Property.ofValue(server.url()))
             .build();
         Push.Output pushOutput = push.run(cloneRunContext);
 
@@ -230,6 +246,7 @@ class PushTest extends AbstractGitTest {
                 )
             )
             .branch(Property.ofValue(branchName))
+            .kestraUrl(Property.ofValue(server.url()))
             .build();
 
         var ot = push.run(runContext);
@@ -292,6 +309,7 @@ class PushTest extends AbstractGitTest {
             .username(Property.ofValue(pat))
             .password(Property.ofValue(pat))
             .branch(Property.ofValue(branchName))
+            .kestraUrl(Property.ofValue(server.url()))
             .build();
         var rc1 = runContextFactory.of();
         runContextFactory.initializer().forExecutor((DefaultRunContext) rc1);
@@ -348,6 +366,7 @@ class PushTest extends AbstractGitTest {
             .username(Property.ofValue(pat))
             .password(Property.ofValue(pat))
             .branch(Property.ofValue(branchName))
+            .kestraUrl(Property.ofValue(server.url()))
             .build();
         RunContext runContext = runContextFactory.of();
         runContextFactory.initializer().forExecutor((DefaultRunContext) runContext);
@@ -409,6 +428,7 @@ class PushTest extends AbstractGitTest {
                 )
             )
             .branch(Property.ofValue(branchName))
+            .kestraUrl(Property.ofValue(server.url()))
             .build();
 
         push.run(runContext);
@@ -463,6 +483,7 @@ class PushTest extends AbstractGitTest {
             .username(Property.ofValue(pat))
             .password(Property.ofValue(pat))
             .branch(Property.ofValue(branchName))
+            .kestraUrl(Property.ofValue(server.url()))
             .build();
 
         try {
@@ -531,6 +552,7 @@ class PushTest extends AbstractGitTest {
                     .build()
             )
             .branch(Property.ofValue(branchName))
+            .kestraUrl(Property.ofValue(server.url()))
             .build();
 
         try {
@@ -596,6 +618,7 @@ class PushTest extends AbstractGitTest {
                     .gitDirectory(Property.ofValue("my-flows"))
                     .build()
             )
+            .kestraUrl(Property.ofValue(server.url()))
             .build();
 
         try {

--- a/src/test/java/io/kestra/plugin/git/SyncDashboardsContainerTest.java
+++ b/src/test/java/io/kestra/plugin/git/SyncDashboardsContainerTest.java
@@ -1,0 +1,75 @@
+package io.kestra.plugin.git;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.DefaultRunContext;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.RunContextFactory;
+import io.micronaut.context.annotation.Value;
+
+import jakarta.inject.Inject;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * Integration test for {@link SyncDashboards} against a live Kestra container.
+ * Complements (does not replace) the unit-level {@link SyncDashboardsTest} mock-server tests.
+ *
+ * <p>The Kestra container is started once per class by {@link AbstractKestraContainerTest}.
+ * Kestra API credentials are hardcoded for test use only.
+ * GitHub credentials are read from the {@code kestra.git.pat} Micronaut property (set via {@code GH_PERSONAL_TOKEN}).
+ */
+@KestraTest
+@io.micronaut.context.annotation.Property(name = "kestra.tasks.sdk.authentication.username", value = "admin@admin.com")
+@io.micronaut.context.annotation.Property(name = "kestra.tasks.sdk.authentication.password", value = "Root!1234")
+public class SyncDashboardsContainerTest extends AbstractKestraContainerTest {
+
+    private static final String TARGET_NAMESPACE = "io.kestra.tests.container.syncdashboards";
+    private static final String REPO_URL = "https://github.com/kestra-io/unit-tests";
+    private static final String BRANCH = "sync-dashboards";
+    private static final String GIT_DIRECTORY = "to_clone/_dashboards";
+
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    @Value("${kestra.git.pat}")
+    private String gitPat;
+
+    @Test
+    void syncDashboardsFromGit_shouldProduceDiffOutput() throws Exception {
+        var runContext = buildRunContext();
+
+        var task = SyncDashboards.builder()
+            .url(Property.ofValue(REPO_URL))
+            .username(Property.ofValue(gitPat))
+            .password(Property.ofValue(gitPat))
+            .branch(Property.ofValue(BRANCH))
+            .gitDirectory(Property.ofValue(GIT_DIRECTORY))
+            .kestraUrl(Property.ofValue(kestraUrl))
+            .build();
+
+        SyncDashboards.Output output = task.run(runContext);
+
+        assertThat("output must be present", output, notNullValue());
+        assertThat("dashboards diff URI must be present", output.getDashboards(), notNullValue());
+    }
+
+    private RunContext buildRunContext() {
+        var rc = runContextFactory.of(
+            Map.of(
+                "flow", Map.of(
+                    "tenantId", "main",
+                    "namespace", TARGET_NAMESPACE,
+                    "id", "sync-dashboards-container-test"
+                )
+            )
+        );
+        runContextFactory.initializer().forExecutor((DefaultRunContext) rc);
+        return rc;
+    }
+}

--- a/src/test/java/io/kestra/plugin/git/SyncDashboardsTest.java
+++ b/src/test/java/io/kestra/plugin/git/SyncDashboardsTest.java
@@ -17,6 +17,7 @@ import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.dashboards.Dashboard;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.repositories.DashboardRepositoryInterface;
+import io.kestra.core.runners.DefaultRunContext;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.serializers.JacksonMapper;
@@ -187,7 +188,7 @@ public class SyncDashboardsTest extends AbstractGitTest {
     }
 
     private RunContext runContext() {
-        return runContextFactory.of(
+        var rc = runContextFactory.of(
             Map.of(
                 "flow", Map.of(
                     "tenantId", SyncDashboardsTest.TENANT_ID,
@@ -201,6 +202,8 @@ public class SyncDashboardsTest extends AbstractGitTest {
                 "gitDirectory", SyncDashboardsTest.GIT_DIRECTORY
             )
         );
+        runContextFactory.initializer().forExecutor((DefaultRunContext) rc);
+        return rc;
     }
 
     static DashboardDiffOutput diffMapToDashboardDiffOutput(Map<String, Object> diffMap) {

--- a/src/test/java/io/kestra/plugin/git/SyncDashboardsTest.java
+++ b/src/test/java/io/kestra/plugin/git/SyncDashboardsTest.java
@@ -158,6 +158,7 @@ public class SyncDashboardsTest extends AbstractGitTest {
             .gitDirectory(Property.ofExpression("{{gitDirectory}}"))
             .delete(Property.ofValue(delete))
             .dryRun(Property.ofValue(true))
+            .kestraUrl(Property.ofValue(server.url()))
             .build();
 
         SyncDashboards.Output syncOutput = task.run(runContext);

--- a/src/test/java/io/kestra/plugin/git/SyncDashboardsTest.java
+++ b/src/test/java/io/kestra/plugin/git/SyncDashboardsTest.java
@@ -7,6 +7,7 @@ import java.time.Instant;
 import java.util.*;
 
 import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -47,6 +48,18 @@ public class SyncDashboardsTest extends AbstractGitTest {
     @Inject
     private DashboardRepositoryInterface dashboardRepositoryInterface;
 
+    private MockKestraApiServer server;
+
+    @BeforeEach
+    void startMockServer() throws IOException {
+        server = MockKestraApiServer.start(dashboardRepositoryInterface);
+    }
+
+    @AfterEach
+    void stopMockServer() {
+        server.close();
+    }
+
     @BeforeEach
     void init() {
         dashboardRepositoryInterface.findAll(TENANT_ID).forEach(dashboard ->
@@ -84,6 +97,7 @@ public class SyncDashboardsTest extends AbstractGitTest {
             .branch(Property.ofExpression("{{branch}}"))
             .gitDirectory(Property.ofExpression("{{gitDirectory}}"))
             .delete(Property.ofValue(delete))
+            .kestraUrl(Property.ofValue(server.url()))
             .build();
 
         SyncDashboards.Output syncOutput = task.run(runContext);

--- a/src/test/java/io/kestra/plugin/git/SyncFlowContainerTest.java
+++ b/src/test/java/io/kestra/plugin/git/SyncFlowContainerTest.java
@@ -1,0 +1,83 @@
+package io.kestra.plugin.git;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.DefaultRunContext;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.RunContextFactory;
+import io.kestra.sdk.model.Flow;
+import io.micronaut.context.annotation.Value;
+
+import jakarta.inject.Inject;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * Integration test for {@link SyncFlow} against a live Kestra container.
+ * Complements (does not replace) the unit-level {@link SyncFlowTest} mock-server tests.
+ *
+ * <p>The Kestra container is started once per class by {@link AbstractKestraContainerTest}.
+ * Kestra API credentials are hardcoded for test use only.
+ * GitHub credentials are read from the {@code kestra.git.pat} Micronaut property (set via {@code GH_PERSONAL_TOKEN}).
+ */
+@KestraTest
+@io.micronaut.context.annotation.Property(name = "kestra.tasks.sdk.authentication.username", value = "admin@admin.com")
+@io.micronaut.context.annotation.Property(name = "kestra.tasks.sdk.authentication.password", value = "Root!1234")
+public class SyncFlowContainerTest extends AbstractKestraContainerTest {
+
+    private static final String TARGET_NAMESPACE = "io.kestra.tests.container.syncflow";
+    private static final String REPO_URL = "https://github.com/kestra-io/unit-tests";
+    private static final String BRANCH = "sync";
+    private static final String FLOW_PATH = "to_clone/_flows/first-flow.yml";
+
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    @Value("${kestra.git.pat}")
+    private String gitPat;
+
+    @Test
+    void syncFlowFromGit_shouldLandFlowInKestra() throws Exception {
+        var runContext = buildRunContext();
+
+        var task = SyncFlow.builder()
+            .url(Property.ofValue(REPO_URL))
+            .username(Property.ofValue(gitPat))
+            .password(Property.ofValue(gitPat))
+            .branch(Property.ofValue(BRANCH))
+            .flowPath(Property.ofValue(FLOW_PATH))
+            .targetNamespace(Property.ofValue(TARGET_NAMESPACE))
+            .kestraUrl(Property.ofValue(kestraUrl))
+            .build();
+
+        SyncFlow.Output output = task.run(runContext);
+
+        assertThat("output must be present", output, notNullValue());
+        assertThat("flowId must be present", output.getFlowId(), notNullValue());
+        assertThat("namespace must match target", output.getNamespace(), is(TARGET_NAMESPACE));
+        assertThat("revision must be present", output.getRevision(), notNullValue());
+
+        List<Flow> flows = kestraTestDataUtils.listFlowsByNamespace(TARGET_NAMESPACE, TENANT_ID);
+        assertThat("at least one flow must have been synced to the target namespace", flows, not(empty()));
+    }
+
+    private RunContext buildRunContext() {
+        var rc = runContextFactory.of(
+            Map.of(
+                "flow", Map.of(
+                    "tenantId", "main",
+                    "namespace", TARGET_NAMESPACE,
+                    "id", "sync-flow-container-test"
+                )
+            )
+        );
+        runContextFactory.initializer().forExecutor((DefaultRunContext) rc);
+        return rc;
+    }
+}

--- a/src/test/java/io/kestra/plugin/git/SyncFlowTest.java
+++ b/src/test/java/io/kestra/plugin/git/SyncFlowTest.java
@@ -1,18 +1,15 @@
 package io.kestra.plugin.git;
 
-import java.util.List;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import com.sun.net.httpserver.HttpServer;
+
 import io.kestra.core.junit.annotations.KestraTest;
-import io.kestra.core.models.flows.Flow;
-import io.kestra.core.models.flows.FlowWithSource;
-import io.kestra.core.models.flows.GenericFlow;
 import io.kestra.core.models.property.Property;
-import io.kestra.core.repositories.FlowRepositoryInterface;
-import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.tenant.TenantService;
 
@@ -20,6 +17,7 @@ import jakarta.inject.Inject;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @KestraTest
 public class SyncFlowTest extends AbstractGitTest {
@@ -30,113 +28,238 @@ public class SyncFlowTest extends AbstractGitTest {
     @Inject
     private RunContextFactory runContextFactory;
 
-    @Inject
-    private FlowRepositoryInterface flowRepositoryInterface;
-
-    @BeforeEach
-    void init() {
-        flowRepositoryInterface.findAllForAllTenants().forEach(f ->
-        {
-            flowRepositoryInterface.delete(FlowWithSource.of(f, ""));
-        });
-    }
-
     @Test
     void createNewFlow() throws Exception {
-        RunContext runContext = runContext();
+        var importResponse = "[\"first-flow\"]".getBytes(StandardCharsets.UTF_8);
+        var flowResponse = """
+            {
+              "id": "first-flow",
+              "namespace": "io.kestra.synced",
+              "revision": 1,
+              "disabled": false,
+              "deleted": false,
+              "tasks": []
+            }
+            """.getBytes(StandardCharsets.UTF_8);
 
-        assertThat(flowRepositoryInterface.findAllForAllTenants().size(), is(0));
+        var server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/api/v1/" + TENANT_ID + "/flows/import", exchange ->
+        {
+            exchange.getRequestBody().readAllBytes();
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, importResponse.length);
+            exchange.getResponseBody().write(importResponse);
+            exchange.close();
+        });
+        server.createContext("/api/v1/" + TENANT_ID + "/flows/" + TARGET_NAMESPACE + "/first-flow", exchange ->
+        {
+            exchange.getRequestBody().readAllBytes();
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, flowResponse.length);
+            exchange.getResponseBody().write(flowResponse);
+            exchange.close();
+        });
+        server.start();
 
-        SyncFlow task = SyncFlow.builder()
-            .url(Property.ofExpression("{{url}}"))
-            .username(Property.ofExpression("{{pat}}"))
-            .password(Property.ofExpression("{{pat}}"))
-            .branch(Property.ofExpression("{{branch}}"))
-            .targetNamespace(Property.ofValue(TARGET_NAMESPACE))
-            .flowPath(Property.ofValue("to_clone/_flows/first-flow.yml"))
-            .build();
+        try {
+            var kestraUrl = "http://localhost:" + server.getAddress().getPort();
+            SyncFlow task = SyncFlow.builder()
+                .url(Property.ofExpression("{{url}}"))
+                .username(Property.ofExpression("{{pat}}"))
+                .password(Property.ofExpression("{{pat}}"))
+                .branch(Property.ofExpression("{{branch}}"))
+                .targetNamespace(Property.ofValue(TARGET_NAMESPACE))
+                .flowPath(Property.ofValue("to_clone/_flows/first-flow.yml"))
+                .kestraUrl(Property.ofValue(kestraUrl))
+                .auth(AbstractKestraTask.Auth.builder()
+                    .username(Property.ofValue("user"))
+                    .password(Property.ofValue("pass"))
+                    .build())
+                .build();
 
-        SyncFlow.Output output = task.run(runContext);
+            SyncFlow.Output output = task.run(runContext());
 
-        assertThat(output.getFlowId(), is("first-flow"));
-        assertThat(output.getNamespace(), is(TARGET_NAMESPACE));
-        assertThat(output.getRevision(), is(1));
-
-        List<Flow> flows = flowRepositoryInterface.findAllForAllTenants();
-        assertThat(flows, hasSize(1));
-
-        Flow syncedFlow = flows.getFirst();
-        assertThat(syncedFlow.getId(), is("first-flow"));
-        assertThat(syncedFlow.getNamespace(), is(TARGET_NAMESPACE));
-        assertThat(syncedFlow.getRevision(), is(1));
+            assertThat(output.getFlowId(), is("first-flow"));
+            assertThat(output.getNamespace(), is(TARGET_NAMESPACE));
+            assertThat(output.getRevision(), is(1));
+        } finally {
+            server.stop(0);
+        }
     }
 
     @Test
     void updateExistingFlow() throws Exception {
-        RunContext runContext = runContext();
+        var importResponse = "[\"second-flow\"]".getBytes(StandardCharsets.UTF_8);
+        var flowResponse = """
+            {
+              "id": "second-flow",
+              "namespace": "io.kestra.synced",
+              "revision": 2,
+              "disabled": false,
+              "deleted": false,
+              "tasks": []
+            }
+            """.getBytes(StandardCharsets.UTF_8);
 
-        String initialSource = "id: second-flow\nnamespace: " + TARGET_NAMESPACE + "\ntasks:\n  - id: log\n    type: io.kestra.core.tasks.log.Log\n    message: 'v1'";
-        GenericFlow flow = GenericFlow.fromYaml(TENANT_ID, initialSource);
+        var server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/api/v1/" + TENANT_ID + "/flows/import", exchange ->
+        {
+            exchange.getRequestBody().readAllBytes();
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, importResponse.length);
+            exchange.getResponseBody().write(importResponse);
+            exchange.close();
+        });
+        server.createContext("/api/v1/" + TENANT_ID + "/flows/" + TARGET_NAMESPACE + "/second-flow", exchange ->
+        {
+            exchange.getRequestBody().readAllBytes();
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, flowResponse.length);
+            exchange.getResponseBody().write(flowResponse);
+            exchange.close();
+        });
+        server.start();
 
-        flowRepositoryInterface.create(
-            flow.toBuilder().source(initialSource).build()
-        );
+        try {
+            var kestraUrl = "http://localhost:" + server.getAddress().getPort();
+            SyncFlow task = SyncFlow.builder()
+                .url(Property.ofExpression("{{url}}"))
+                .username(Property.ofExpression("{{pat}}"))
+                .password(Property.ofExpression("{{pat}}"))
+                .branch(Property.ofExpression("{{branch}}"))
+                .targetNamespace(Property.ofValue(TARGET_NAMESPACE))
+                .flowPath(Property.ofValue("to_clone/_flows/second-flow.yml"))
+                .kestraUrl(Property.ofValue(kestraUrl))
+                .auth(AbstractKestraTask.Auth.builder()
+                    .username(Property.ofValue("user"))
+                    .password(Property.ofValue("pass"))
+                    .build())
+                .build();
 
-        Flow initialFlow = flowRepositoryInterface.findAllForAllTenants().get(0);
-        assertThat(initialFlow.getRevision(), is(1));
+            SyncFlow.Output output = task.run(runContext());
 
-        SyncFlow task = SyncFlow.builder()
-            .url(Property.ofExpression("{{url}}"))
-            .username(Property.ofExpression("{{pat}}"))
-            .password(Property.ofExpression("{{pat}}"))
-            .branch(Property.ofExpression("{{branch}}"))
-            .targetNamespace(Property.ofValue(TARGET_NAMESPACE))
-            .flowPath(Property.ofValue("to_clone/_flows/second-flow.yml"))
-            .build();
-
-        SyncFlow.Output output = task.run(runContext);
-
-        assertThat(output.getRevision(), is(2));
-
-        List<FlowWithSource> flowsWithSource = flowRepositoryInterface.findByNamespacePrefixWithSource(TENANT_ID, TARGET_NAMESPACE);
-        assertThat(flowsWithSource, hasSize(1));
-
-        FlowWithSource updatedFlowWithSource = flowsWithSource.getFirst();
-
-        assertThat(updatedFlowWithSource.getId(), is("second-flow"));
-        assertThat(updatedFlowWithSource.getRevision(), is(2));
-        assertThat(updatedFlowWithSource.getSource(), containsString("Hello from second-flow"));
+            assertThat(output.getRevision(), is(2));
+            assertThat(output.getFlowId(), is("second-flow"));
+            assertThat(output.getNamespace(), is(TARGET_NAMESPACE));
+        } finally {
+            server.stop(0);
+        }
     }
 
     @Test
-    void dryRun() throws Exception {
-        RunContext runContext = runContext();
+    void dryRun_newFlow() throws Exception {
+        // validate returns empty violations (flow is valid)
+        var validateResponse = "[]".getBytes(StandardCharsets.UTF_8);
 
-        assertThat(flowRepositoryInterface.findAllForAllTenants().size(), is(0));
+        var server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/api/v1/" + TENANT_ID + "/flows/validate", exchange ->
+        {
+            exchange.getRequestBody().readAllBytes();
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, validateResponse.length);
+            exchange.getResponseBody().write(validateResponse);
+            exchange.close();
+        });
+        // Return 404 for flow lookup: flow doesn't exist yet, so projected revision is 1
+        server.createContext("/api/v1/" + TENANT_ID + "/flows/" + TARGET_NAMESPACE + "/first-flow", exchange ->
+        {
+            exchange.getRequestBody().readAllBytes();
+            exchange.sendResponseHeaders(404, -1);
+            exchange.close();
+        });
+        server.start();
 
-        SyncFlow task = SyncFlow.builder()
-            .url(Property.ofExpression("{{url}}"))
-            .username(Property.ofExpression("{{pat}}"))
-            .password(Property.ofExpression("{{pat}}"))
-            .branch(Property.ofExpression("{{branch}}"))
-            .targetNamespace(Property.ofValue(TARGET_NAMESPACE))
-            .flowPath(Property.ofValue("to_clone/_flows/first-flow.yml"))
-            .dryRun(Property.ofValue(true))
-            .build();
+        try {
+            var kestraUrl = "http://localhost:" + server.getAddress().getPort();
+            SyncFlow task = SyncFlow.builder()
+                .url(Property.ofExpression("{{url}}"))
+                .username(Property.ofExpression("{{pat}}"))
+                .password(Property.ofExpression("{{pat}}"))
+                .branch(Property.ofExpression("{{branch}}"))
+                .targetNamespace(Property.ofValue(TARGET_NAMESPACE))
+                .flowPath(Property.ofValue("to_clone/_flows/first-flow.yml"))
+                .dryRun(Property.ofValue(true))
+                .kestraUrl(Property.ofValue(kestraUrl))
+                .auth(AbstractKestraTask.Auth.builder()
+                    .username(Property.ofValue("user"))
+                    .password(Property.ofValue("pass"))
+                    .build())
+                .build();
 
-        SyncFlow.Output output = task.run(runContext);
+            SyncFlow.Output output = task.run(runContext());
 
-        assertThat(output.getFlowId(), is("first-flow"));
-        assertThat(output.getNamespace(), is(TARGET_NAMESPACE));
-        assertThat(output.getRevision(), is(1));
+            assertThat(output.getFlowId(), is("first-flow"));
+            assertThat(output.getNamespace(), is(TARGET_NAMESPACE));
+            // Projected revision for a new flow is 1
+            assertThat(output.getRevision(), is(1));
+        } finally {
+            server.stop(0);
+        }
+    }
 
-        assertThat(flowRepositoryInterface.findAllForAllTenants().size(), is(0));
+    @Test
+    void dryRun_existingFlow() throws Exception {
+        var validateResponse = "[]".getBytes(StandardCharsets.UTF_8);
+        var existingFlowResponse = """
+            {
+              "id": "first-flow",
+              "namespace": "io.kestra.synced",
+              "revision": 3,
+              "disabled": false,
+              "deleted": false,
+              "tasks": []
+            }
+            """.getBytes(StandardCharsets.UTF_8);
+
+        var server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/api/v1/" + TENANT_ID + "/flows/validate", exchange ->
+        {
+            exchange.getRequestBody().readAllBytes();
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, validateResponse.length);
+            exchange.getResponseBody().write(validateResponse);
+            exchange.close();
+        });
+        server.createContext("/api/v1/" + TENANT_ID + "/flows/" + TARGET_NAMESPACE + "/first-flow", exchange ->
+        {
+            exchange.getRequestBody().readAllBytes();
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, existingFlowResponse.length);
+            exchange.getResponseBody().write(existingFlowResponse);
+            exchange.close();
+        });
+        server.start();
+
+        try {
+            var kestraUrl = "http://localhost:" + server.getAddress().getPort();
+            SyncFlow task = SyncFlow.builder()
+                .url(Property.ofExpression("{{url}}"))
+                .username(Property.ofExpression("{{pat}}"))
+                .password(Property.ofExpression("{{pat}}"))
+                .branch(Property.ofExpression("{{branch}}"))
+                .targetNamespace(Property.ofValue(TARGET_NAMESPACE))
+                .flowPath(Property.ofValue("to_clone/_flows/first-flow.yml"))
+                .dryRun(Property.ofValue(true))
+                .kestraUrl(Property.ofValue(kestraUrl))
+                .auth(AbstractKestraTask.Auth.builder()
+                    .username(Property.ofValue("user"))
+                    .password(Property.ofValue("pass"))
+                    .build())
+                .build();
+
+            SyncFlow.Output output = task.run(runContext());
+
+            assertThat(output.getFlowId(), is("first-flow"));
+            assertThat(output.getNamespace(), is(TARGET_NAMESPACE));
+            // Projected revision: existing (3) + 1 = 4
+            assertThat(output.getRevision(), is(4));
+        } finally {
+            server.stop(0);
+        }
     }
 
     @Test
     void fileNotFound() {
-        RunContext runContext = runContext();
-
         SyncFlow task = SyncFlow.builder()
             .url(Property.ofExpression("{{url}}"))
             .username(Property.ofExpression("{{pat}}"))
@@ -144,16 +267,17 @@ public class SyncFlowTest extends AbstractGitTest {
             .branch(Property.ofExpression("{{branch}}"))
             .targetNamespace(Property.ofValue(TARGET_NAMESPACE))
             .flowPath(Property.ofValue("non_existent_file.yml"))
+            // No kestraUrl needed since the task will fail before reaching the API
             .build();
 
-        Exception exception = org.junit.jupiter.api.Assertions.assertThrows(
+        Exception exception = assertThrows(
             java.io.FileNotFoundException.class,
-            () -> task.run(runContext)
+            () -> task.run(runContext())
         );
         assertThat(exception.getMessage(), containsString("non_existent_file.yml"));
     }
 
-    private RunContext runContext() {
+    private io.kestra.core.runners.RunContext runContext() {
         return runContextFactory.of(
             Map.of(
                 "flow", Map.of(

--- a/src/test/java/io/kestra/plugin/git/SyncFlowsContainerTest.java
+++ b/src/test/java/io/kestra/plugin/git/SyncFlowsContainerTest.java
@@ -63,7 +63,7 @@ public class SyncFlowsContainerTest extends AbstractKestraContainerTest {
 
         assertThat("diff file URI must be present", output.getFlows(), notNullValue());
 
-        List<Flow> flows = kestraTestDataUtils.listFlowsByNamespace(TARGET_NAMESPACE, null);
+        List<Flow> flows = kestraTestDataUtils.listFlowsByNamespace(TARGET_NAMESPACE, TENANT_ID);
         assertThat("at least one flow must have been synced to the target namespace", flows, not(empty()));
     }
 

--- a/src/test/java/io/kestra/plugin/git/SyncFlowsContainerTest.java
+++ b/src/test/java/io/kestra/plugin/git/SyncFlowsContainerTest.java
@@ -1,0 +1,83 @@
+package io.kestra.plugin.git;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.DefaultRunContext;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.RunContextFactory;
+import io.kestra.sdk.model.Flow;
+import io.micronaut.context.annotation.Value;
+
+import jakarta.inject.Inject;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * Integration test for {@link SyncFlows} against a live Kestra container.
+ * Complements (does not replace) the {@link SyncFlowsTest} mock-server tests.
+ *
+ * <p>The Kestra container is started once per class by {@link AbstractKestraContainerTest}.
+ * Kestra API credentials ({@code admin@admin.com} / {@code Root!1234}) are hardcoded for test use only.
+ * GitHub credentials are read from the {@code kestra.git.pat} Micronaut property (set via {@code GH_PERSONAL_TOKEN}).
+ */
+@KestraTest
+@io.micronaut.context.annotation.Property(name = "kestra.tasks.sdk.authentication.username", value = "admin@admin.com")
+@io.micronaut.context.annotation.Property(name = "kestra.tasks.sdk.authentication.password", value = "Root!1234")
+public class SyncFlowsContainerTest extends AbstractKestraContainerTest {
+
+    private static final String TARGET_NAMESPACE = "io.kestra.tests.container";
+    private static final String REPO_URL = "https://github.com/kestra-io/unit-tests";
+    private static final String BRANCH = "sync";
+    private static final String GIT_DIRECTORY = "to_clone/_flows";
+
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    // Same PAT used by existing SyncFlowsTest — required for jGit to clone even public repos
+    @Value("${kestra.git.pat}")
+    private String gitPat;
+
+    @Test
+    void syncFlowsFromGit_shouldLandFlowsInKestra() throws Exception {
+        var runContext = buildRunContext();
+
+        var task = SyncFlows.builder()
+            .url(Property.ofValue(REPO_URL))
+            .username(Property.ofValue(gitPat))
+            .password(Property.ofValue(gitPat))
+            .branch(Property.ofValue(BRANCH))
+            .gitDirectory(Property.ofValue(GIT_DIRECTORY))
+            .targetNamespace(Property.ofValue(TARGET_NAMESPACE))
+            .includeChildNamespaces(Property.ofValue(false))
+            .delete(Property.ofValue(false))
+            .kestraUrl(Property.ofValue(kestraUrl))
+            .build();
+
+        SyncFlows.Output output = task.run(runContext);
+
+        assertThat("diff file URI must be present", output.getFlows(), notNullValue());
+
+        List<Flow> flows = kestraTestDataUtils.listFlowsByNamespace(TARGET_NAMESPACE, null);
+        assertThat("at least one flow must have been synced to the target namespace", flows, not(empty()));
+    }
+
+    private RunContext buildRunContext() {
+        var rc = runContextFactory.of(
+            Map.of(
+                "flow", Map.of(
+                    "tenantId", "main",
+                    "namespace", TARGET_NAMESPACE,
+                    "id", "sync-flows-container-test"
+                )
+            )
+        );
+        runContextFactory.initializer().forExecutor((DefaultRunContext) rc);
+        return rc;
+    }
+}

--- a/src/test/java/io/kestra/plugin/git/SyncFlowsContainerTest.java
+++ b/src/test/java/io/kestra/plugin/git/SyncFlowsContainerTest.java
@@ -27,6 +27,8 @@ import static org.hamcrest.Matchers.*;
  * GitHub credentials are read from the {@code kestra.git.pat} Micronaut property (set via {@code GH_PERSONAL_TOKEN}).
  */
 @KestraTest
+@io.micronaut.context.annotation.Property(name = "kestra.tasks.sdk.authentication.username", value = "admin@admin.com")
+@io.micronaut.context.annotation.Property(name = "kestra.tasks.sdk.authentication.password", value = "Root!1234")
 public class SyncFlowsContainerTest extends AbstractKestraContainerTest {
 
     private static final String TARGET_NAMESPACE = "io.kestra.tests.container";

--- a/src/test/java/io/kestra/plugin/git/SyncFlowsContainerTest.java
+++ b/src/test/java/io/kestra/plugin/git/SyncFlowsContainerTest.java
@@ -27,8 +27,6 @@ import static org.hamcrest.Matchers.*;
  * GitHub credentials are read from the {@code kestra.git.pat} Micronaut property (set via {@code GH_PERSONAL_TOKEN}).
  */
 @KestraTest
-@io.micronaut.context.annotation.Property(name = "kestra.tasks.sdk.authentication.username", value = "admin@admin.com")
-@io.micronaut.context.annotation.Property(name = "kestra.tasks.sdk.authentication.password", value = "Root!1234")
 public class SyncFlowsContainerTest extends AbstractKestraContainerTest {
 
     private static final String TARGET_NAMESPACE = "io.kestra.tests.container";

--- a/src/test/java/io/kestra/plugin/git/SyncFlowsTest.java
+++ b/src/test/java/io/kestra/plugin/git/SyncFlowsTest.java
@@ -72,7 +72,6 @@ public class SyncFlowsTest extends AbstractGitTest {
 
     @BeforeEach
     void init() {
-        previousRevisionByUid.clear();
         flowRepositoryInterface.findAllForAllTenants().forEach(f ->
         {
             Flow deleted = flowRepositoryInterface.delete(FlowWithSource.of(f, ""));
@@ -194,6 +193,7 @@ public class SyncFlowsTest extends AbstractGitTest {
             runContext, syncOutput.diffFileUri(),
             defaultCaseDiffs(
                 true,
+                false,
                 new HashMap<>(
                     Map.of(
                         "syncState", "DELETED", "flowId", "flow-to-delete", "namespace", "my.namespace.child", "revision",
@@ -285,7 +285,7 @@ public class SyncFlowsTest extends AbstractGitTest {
             .run(cloneRunContext);
         assertFlows(cloneRunContext.workingDir().path().resolve(Path.of(GIT_DIRECTORY)).toFile(), true, selfFlowSource, nonVersionedFlowSource);
 
-        assertDiffs(runContext, syncOutput.diffFileUri(), defaultCaseDiffs(true));
+        assertDiffs(runContext, syncOutput.diffFileUri(), defaultCaseDiffs(true, false));
     }
 
     @Test
@@ -382,6 +382,7 @@ public class SyncFlowsTest extends AbstractGitTest {
         assertDiffs(
             runContext, syncOutput.diffFileUri(),
             defaultCaseDiffs(
+                false,
                 false,
                 new HashMap<>(
                     Map.of(
@@ -482,6 +483,7 @@ public class SyncFlowsTest extends AbstractGitTest {
         assertDiffs(
             runContext, syncOutput.diffFileUri(),
             defaultCaseDiffs(
+                true,
                 true,
                 new HashMap<>(
                     Map.of(
@@ -625,7 +627,7 @@ public class SyncFlowsTest extends AbstractGitTest {
         assertThat(ex.getMessage(), containsString("demo-invalid-flow"));
     }
 
-    private List<Map<String, Object>> defaultCaseDiffs(boolean includeSubNamespaces, Map<String, Object>... additionalDiffs) {
+    private List<Map<String, Object>> defaultCaseDiffs(boolean includeSubNamespaces, boolean dryRun, Map<String, Object>... additionalDiffs) {
         List<Map<String, Object>> diffs = new ArrayList<>(
             List.of(
                 Map.of(
@@ -638,7 +640,7 @@ public class SyncFlowsTest extends AbstractGitTest {
                 ),
                 Map.of(
                     "gitPath", "to_clone/_flows/second-flow.yml", "syncState", "ADDED", "flowId", "second-flow", "namespace", NAMESPACE, "revision",
-                    previousRevisionByUid.getOrDefault(FlowId.uidWithoutRevision(TENANT_ID, NAMESPACE, "second-flow"), 0) + 1
+                    dryRun ? 1 : previousRevisionByUid.getOrDefault(FlowId.uidWithoutRevision(TENANT_ID, NAMESPACE, "second-flow"), 0) + 1
                 )
             )
         );
@@ -647,7 +649,7 @@ public class SyncFlowsTest extends AbstractGitTest {
             diffs.add(
                 Map.of(
                     "gitPath", "to_clone/_flows/nested/namespace/nested_flow.yaml", "syncState", "ADDED", "flowId", "nested-flow", "namespace", "my.namespace.nested.namespace", "revision",
-                    previousRevisionByUid.getOrDefault(FlowId.uidWithoutRevision(TENANT_ID, "my.namespace.nested.namespace", "nested-flow"), 0) + 1
+                    dryRun ? 1 : previousRevisionByUid.getOrDefault(FlowId.uidWithoutRevision(TENANT_ID, "my.namespace.nested.namespace", "nested-flow"), 0) + 1
                 )
             );
         }

--- a/src/test/java/io/kestra/plugin/git/SyncFlowsTest.java
+++ b/src/test/java/io/kestra/plugin/git/SyncFlowsTest.java
@@ -72,6 +72,7 @@ public class SyncFlowsTest extends AbstractGitTest {
 
     @BeforeEach
     void init() {
+        previousRevisionByUid.clear();
         flowRepositoryInterface.findAllForAllTenants().forEach(f ->
         {
             Flow deleted = flowRepositoryInterface.delete(FlowWithSource.of(f, ""));

--- a/src/test/java/io/kestra/plugin/git/SyncFlowsTest.java
+++ b/src/test/java/io/kestra/plugin/git/SyncFlowsTest.java
@@ -26,6 +26,7 @@ import io.kestra.core.models.flows.GenericFlow;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.GenericTask;
 import io.kestra.core.repositories.FlowRepositoryInterface;
+import io.kestra.core.runners.DefaultRunContext;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.serializers.JacksonMapper;
@@ -535,6 +536,7 @@ public class SyncFlowsTest extends AbstractGitTest {
                 "namespace", NAMESPACE
             )
         );
+        runContextFactory.initializer().forExecutor((DefaultRunContext) runContext);
 
         SyncFlows task = SyncFlows.builder()
             .url(Property.ofExpression("{{url}}"))
@@ -588,6 +590,7 @@ public class SyncFlowsTest extends AbstractGitTest {
                 "namespace", NAMESPACE
             )
         );
+        runContextFactory.initializer().forExecutor((DefaultRunContext) runContext);
 
         SyncFlows task = SyncFlows.builder()
             .url(Property.ofExpression("{{url}}"))
@@ -633,7 +636,7 @@ public class SyncFlowsTest extends AbstractGitTest {
     }
 
     private RunContext runContext() {
-        return runContextFactory.of(
+        var rc = runContextFactory.of(
             Map.of(
                 "flow", Map.of(
                     "tenantId", SyncFlowsTest.TENANT_ID,
@@ -647,6 +650,8 @@ public class SyncFlowsTest extends AbstractGitTest {
                 "gitDirectory", SyncFlowsTest.GIT_DIRECTORY
             )
         );
+        runContextFactory.initializer().forExecutor((DefaultRunContext) rc);
+        return rc;
     }
 
     private static void assertDiffs(RunContext runContext, URI diffFileUri, List<Map<String, Object>> expectedDiffs) throws IOException {

--- a/src/test/java/io/kestra/plugin/git/SyncFlowsTest.java
+++ b/src/test/java/io/kestra/plugin/git/SyncFlowsTest.java
@@ -174,8 +174,6 @@ public class SyncFlowsTest extends AbstractGitTest {
             .build();
         SyncFlows.Output syncOutput = task.run(runContext);
 
-        flowRepositoryInterface.delete(invalidFlow);
-
         flows = flowRepositoryInterface.findAllForAllTenants();
         assertThat(flows, hasSize(6));
 
@@ -198,6 +196,16 @@ public class SyncFlowsTest extends AbstractGitTest {
                     Map.of(
                         "syncState", "DELETED", "flowId", "flow-to-delete", "namespace", "my.namespace.child", "revision",
                         previousRevisionByUid.getOrDefault(FlowId.uidWithoutRevision(TENANT_ID, flowToDelete.getNamespace(), flowToDelete.getId()), 1)
+                    )
+                ) {
+                    {
+                        this.put("gitPath", null);
+                    }
+                },
+                new HashMap<>(
+                    Map.of(
+                        "syncState", "DELETED", "flowId", "validation-failed-flow", "namespace", NAMESPACE, "revision",
+                        previousRevisionByUid.getOrDefault(FlowId.uidWithoutRevision(TENANT_ID, NAMESPACE, "validation-failed-flow"), 1)
                     )
                 ) {
                     {

--- a/src/test/java/io/kestra/plugin/git/SyncFlowsTest.java
+++ b/src/test/java/io/kestra/plugin/git/SyncFlowsTest.java
@@ -12,6 +12,7 @@ import java.util.stream.Stream;
 
 import org.apache.commons.io.IOUtils;
 import org.eclipse.jgit.api.Git;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -56,6 +57,18 @@ public class SyncFlowsTest extends AbstractGitTest {
 
     @Inject
     private FlowRepositoryInterface flowRepositoryInterface;
+
+    private MockKestraApiServer server;
+
+    @BeforeEach
+    void startMockServer() throws IOException {
+        server = MockKestraApiServer.start(flowRepositoryInterface);
+    }
+
+    @AfterEach
+    void stopMockServer() {
+        server.close();
+    }
 
     @BeforeEach
     void init() {
@@ -157,6 +170,7 @@ public class SyncFlowsTest extends AbstractGitTest {
             .delete(Property.ofValue(true))
             .includeChildNamespaces(Property.ofValue(true))
             .ignoreInvalidFlows(Property.ofValue(true))
+            .kestraUrl(Property.ofValue(server.url()))
             .build();
         SyncFlows.Output syncOutput = task.run(runContext);
 
@@ -253,6 +267,7 @@ public class SyncFlowsTest extends AbstractGitTest {
             .gitDirectory(Property.ofExpression("{{gitDirectory}}"))
             .targetNamespace(Property.ofExpression("{{namespace}}"))
             .includeChildNamespaces(Property.ofValue(true))
+            .kestraUrl(Property.ofValue(server.url()))
             .build();
         SyncFlows.Output syncOutput = task.run(runContext);
 
@@ -346,6 +361,7 @@ public class SyncFlowsTest extends AbstractGitTest {
             .targetNamespace(Property.ofExpression("{{namespace}}"))
             .delete(Property.ofValue(true))
             .includeChildNamespaces(Property.ofValue(false))
+            .kestraUrl(Property.ofValue(server.url()))
             .build();
         SyncFlows.Output syncOutput = task.run(runContext);
 
@@ -435,7 +451,7 @@ public class SyncFlowsTest extends AbstractGitTest {
         assertThat(flows, hasSize(5));
         flows.forEach(f -> previousRevisionByUid.put(f.uidWithoutRevision(), f.getRevision()));
 
-        String[] beforeUpdateSources = flowRepositoryInterface.findWithSource(null, TENANT_ID, null).stream()
+        String[] beforeUpdateSources = flowRepositoryInterface.findAllWithSource(TENANT_ID).stream()
             .map(FlowWithSource::getSource)
             .toArray(String[]::new);
 
@@ -449,13 +465,14 @@ public class SyncFlowsTest extends AbstractGitTest {
             .delete(Property.ofValue(true))
             .includeChildNamespaces(Property.ofValue(true))
             .dryRun(Property.ofValue(true))
+            .kestraUrl(Property.ofValue(server.url()))
             .build();
         SyncFlows.Output syncOutput = task.run(runContext);
 
         flows = flowRepositoryInterface.findAllForAllTenants();
         assertThat(flows, hasSize(5));
 
-        String[] afterUpdateSources = flowRepositoryInterface.findWithSource(null, TENANT_ID, null).stream()
+        String[] afterUpdateSources = flowRepositoryInterface.findAllWithSource(TENANT_ID).stream()
             .map(FlowWithSource::getSource)
             .toArray(String[]::new);
 
@@ -490,6 +507,7 @@ public class SyncFlowsTest extends AbstractGitTest {
             .branch(Property.ofExpression("{{branch}}"))
             .gitDirectory(Property.ofValue("nonexistent/path"))
             .targetNamespace(Property.ofExpression("{{namespace}}"))
+            .kestraUrl(Property.ofValue(server.url()))
             .build();
 
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
@@ -544,6 +562,7 @@ public class SyncFlowsTest extends AbstractGitTest {
             .gitDirectory(Property.ofExpression("{{gitDirectory}}"))
             .targetNamespace(Property.ofExpression("{{namespace}}"))
             .ignoreInvalidFlows(Property.ofValue(true))
+            .kestraUrl(Property.ofValue(server.url()))
             .build();
 
         SyncFlows.Output output = task.run(runContext);
@@ -597,6 +616,7 @@ public class SyncFlowsTest extends AbstractGitTest {
             .branch(Property.ofExpression("{{branch}}"))
             .gitDirectory(Property.ofExpression("{{gitDirectory}}"))
             .targetNamespace(Property.ofExpression("{{namespace}}"))
+            .kestraUrl(Property.ofValue(server.url()))
             .build();
 
         FlowProcessingException ex = assertThrows(FlowProcessingException.class, () -> task.run(runContext));

--- a/src/test/java/io/kestra/plugin/git/SyncTest.java
+++ b/src/test/java/io/kestra/plugin/git/SyncTest.java
@@ -25,6 +25,7 @@ import io.kestra.core.models.property.Property;
 import io.kestra.core.queues.QueueFactoryInterface;
 import io.kestra.core.queues.QueueInterface;
 import io.kestra.core.repositories.FlowRepositoryInterface;
+import io.kestra.core.runners.DefaultRunContext;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.storages.StorageContext;
@@ -169,17 +170,17 @@ class SyncTest extends AbstractGitTest {
             .gitDirectory(Property.ofValue(clonedGitDirectory))
             .namespaceFilesDirectory(Property.ofValue(destinationDirectory))
             .build();
-        task.run(
-            runContextFactory.of(
-                Map.of(
-                    "flow", Map.of(
-                        "namespace", NAMESPACE,
-                        "id", selfFlowId,
-                        "tenantId", TENANT_ID
-                    )
+        var syncRc1 = runContextFactory.of(
+            Map.of(
+                "flow", Map.of(
+                    "namespace", NAMESPACE,
+                    "id", selfFlowId,
+                    "tenantId", TENANT_ID
                 )
             )
         );
+        runContextFactory.initializer().forExecutor((DefaultRunContext) syncRc1);
+        task.run(syncRc1);
         // endregion
 
         // region THEN
@@ -275,17 +276,17 @@ class SyncTest extends AbstractGitTest {
             .branch(Property.ofValue(BRANCH))
             .build();
 
-        task.run(
-            runContextFactory.of(
-                Map.of(
-                    "flow", Map.of(
-                        "namespace", NAMESPACE,
-                        "id", selfFlowId,
-                        "tenantId", TENANT_ID
-                    )
+        var syncRc2 = runContextFactory.of(
+            Map.of(
+                "flow", Map.of(
+                    "namespace", NAMESPACE,
+                    "id", selfFlowId,
+                    "tenantId", TENANT_ID
                 )
             )
         );
+        runContextFactory.initializer().forExecutor((DefaultRunContext) syncRc2);
+        task.run(syncRc2);
         // endregion
 
         // region THEN

--- a/src/test/java/io/kestra/plugin/git/SyncTest.java
+++ b/src/test/java/io/kestra/plugin/git/SyncTest.java
@@ -22,7 +22,8 @@ import io.kestra.core.models.executions.LogEntry;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.GenericFlow;
 import io.kestra.core.models.property.Property;
-import io.kestra.core.queues.DispatchQueueInterface;
+import io.kestra.core.queues.QueueFactoryInterface;
+import io.kestra.core.queues.QueueInterface;
 import io.kestra.core.repositories.FlowRepositoryInterface;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
@@ -33,6 +34,8 @@ import io.kestra.core.utils.KestraIgnore;
 import io.kestra.core.utils.TestsUtils;
 
 import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import reactor.core.publisher.Flux;
 
 import static io.kestra.core.utils.Rethrow.throwFunction;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -56,7 +59,8 @@ class SyncTest extends AbstractGitTest {
     private StorageInterface storageInterface;
 
     @Inject
-    private DispatchQueueInterface<LogEntry> logQueue;
+    @Named(QueueFactoryInterface.WORKERTASKLOG_NAMED)
+    private QueueInterface<LogEntry> logQueue;
 
     @BeforeEach
     void init() throws IOException {
@@ -311,7 +315,7 @@ class SyncTest extends AbstractGitTest {
     @Test
     void reconcile_DryRun_ShouldDoNothing() throws Exception {
         List<LogEntry> logs = new CopyOnWriteArrayList<>();
-        logQueue.addListener(logs::add);
+        Flux<LogEntry> receive = TestsUtils.receive(logQueue, l -> logs.add(l.getLeft()));
         String namespace = SyncTest.class.getName().toLowerCase();
 
         String flowSource = """
@@ -382,6 +386,7 @@ class SyncTest extends AbstractGitTest {
         assertHasInfoLog(logs, "~ " + toUpdateFilePath);
         assertHasInfoLog(logs, "- " + someFilePath);
         assertHasInfoLog(logs, "+ /cloned.json");
+        receive.blockLast();
     }
 
     private static void assertHasInfoLog(List<LogEntry> logs, String expectedMessage) {

--- a/src/test/java/io/kestra/plugin/git/SyncTest.java
+++ b/src/test/java/io/kestra/plugin/git/SyncTest.java
@@ -13,6 +13,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.event.Level;
@@ -58,6 +59,18 @@ class SyncTest extends AbstractGitTest {
 
     @Inject
     private StorageInterface storageInterface;
+
+    private MockKestraApiServer server;
+
+    @BeforeEach
+    void startMockServer() throws IOException {
+        server = MockKestraApiServer.start(flowRepositoryInterface);
+    }
+
+    @AfterEach
+    void stopMockServer() {
+        server.close();
+    }
 
     @Inject
     @Named(QueueFactoryInterface.WORKERTASKLOG_NAMED)
@@ -169,6 +182,7 @@ class SyncTest extends AbstractGitTest {
             .branch(Property.ofValue(BRANCH))
             .gitDirectory(Property.ofValue(clonedGitDirectory))
             .namespaceFilesDirectory(Property.ofValue(destinationDirectory))
+            .kestraUrl(Property.ofValue(server.url()))
             .build();
         var syncRc1 = runContextFactory.of(
             Map.of(
@@ -274,6 +288,7 @@ class SyncTest extends AbstractGitTest {
             .username(Property.ofValue(pat))
             .password(Property.ofValue(pat))
             .branch(Property.ofValue(BRANCH))
+            .kestraUrl(Property.ofValue(server.url()))
             .build();
 
         var syncRc2 = runContextFactory.of(
@@ -368,6 +383,7 @@ class SyncTest extends AbstractGitTest {
             .branch(Property.ofValue(BRANCH))
             .gitDirectory(Property.ofValue("to_clone"))
             .dryRun(Property.ofValue(true))
+            .kestraUrl(Property.ofValue(server.url()))
             .build();
         RunContext runContext = TestsUtils.mockRunContext(TenantService.MAIN_TENANT, runContextFactory, task, Collections.emptyMap());
         task.run(runContext);

--- a/src/test/java/io/kestra/plugin/git/SyncTest.java
+++ b/src/test/java/io/kestra/plugin/git/SyncTest.java
@@ -22,8 +22,7 @@ import io.kestra.core.models.executions.LogEntry;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.GenericFlow;
 import io.kestra.core.models.property.Property;
-import io.kestra.core.queues.QueueFactoryInterface;
-import io.kestra.core.queues.QueueInterface;
+import io.kestra.core.queues.DispatchQueueInterface;
 import io.kestra.core.repositories.FlowRepositoryInterface;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
@@ -34,8 +33,6 @@ import io.kestra.core.utils.KestraIgnore;
 import io.kestra.core.utils.TestsUtils;
 
 import jakarta.inject.Inject;
-import jakarta.inject.Named;
-import reactor.core.publisher.Flux;
 
 import static io.kestra.core.utils.Rethrow.throwFunction;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -59,8 +56,7 @@ class SyncTest extends AbstractGitTest {
     private StorageInterface storageInterface;
 
     @Inject
-    @Named(QueueFactoryInterface.WORKERTASKLOG_NAMED)
-    private QueueInterface<LogEntry> logQueue;
+    private DispatchQueueInterface<LogEntry> logQueue;
 
     @BeforeEach
     void init() throws IOException {
@@ -79,7 +75,7 @@ class SyncTest extends AbstractGitTest {
 
             tasks:
               - id: old-task
-                type: io.kestra.core.tasks.log.Log
+                type: io.kestra.plugin.core.log.Log
                 message: Hello from old-task""";
         GenericFlow genericFlow = GenericFlow.fromYaml(TENANT_ID, flowSource);
         flowRepositoryInterface.create(genericFlow);
@@ -235,7 +231,7 @@ class SyncTest extends AbstractGitTest {
 
             tasks:
               - id: old-task
-                type: io.kestra.core.tasks.log.Log
+                type: io.kestra.plugin.core.log.Log
                 message: Hello from old-task""";
         GenericFlow flowToDelete = GenericFlow.fromYaml(TENANT_ID, flowSource);
         flowRepositoryInterface.create(flowToDelete);
@@ -315,7 +311,7 @@ class SyncTest extends AbstractGitTest {
     @Test
     void reconcile_DryRun_ShouldDoNothing() throws Exception {
         List<LogEntry> logs = new CopyOnWriteArrayList<>();
-        Flux<LogEntry> receive = TestsUtils.receive(logQueue, l -> logs.add(l.getLeft()));
+        logQueue.addListener(logs::add);
         String namespace = SyncTest.class.getName().toLowerCase();
 
         String flowSource = """
@@ -324,7 +320,7 @@ class SyncTest extends AbstractGitTest {
 
             tasks:
               - id: old-task
-                type: io.kestra.core.tasks.log.Log
+                type: io.kestra.plugin.core.log.Log
                 message: Hello from old-task""";
 
         GenericFlow genericFlow = GenericFlow.fromYaml(TENANT_ID, flowSource);
@@ -386,7 +382,6 @@ class SyncTest extends AbstractGitTest {
         assertHasInfoLog(logs, "~ " + toUpdateFilePath);
         assertHasInfoLog(logs, "- " + someFilePath);
         assertHasInfoLog(logs, "+ /cloned.json");
-        receive.blockLast();
     }
 
     private static void assertHasInfoLog(List<LogEntry> logs, String expectedMessage) {

--- a/src/test/java/io/kestra/plugin/git/TenantSyncTest.java
+++ b/src/test/java/io/kestra/plugin/git/TenantSyncTest.java
@@ -48,7 +48,7 @@ class TenantSyncTest {
 
             tasks:
               - id: log
-                type: io.kestra.core.tasks.log.Log
+                type: io.kestra.plugin.core.log.Log
                 message: hello
             """;
         var exportedZip = zippedYaml("my.namespace/exported-flow.yaml", yaml);

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,10 +1,4 @@
 kestra:
-  worker:
-    controllers:
-      type: STATIC
-      static:
-        endpoints:
-          - host: localhost
   git:
     repository-url: https://github.com/kestra-io/unit-tests
     user:

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,4 +1,10 @@
 kestra:
+  worker:
+    controllers:
+      type: STATIC
+      static:
+        endpoints:
+          - host: localhost
   git:
     repository-url: https://github.com/kestra-io/unit-tests
     user:


### PR DESCRIPTION
## Summary

- Replaces direct `DefaultRunContext`/`FlowService`/`FlowRepositoryInterface` usage in `SyncFlow` and `Push` tasks with the `KestraClient` SDK (`FlowsApi.importFlows`, `FlowsApi.validateFlows`, `FlowsApi.flow`)
- Rewrites `SyncFlowTest` to mock the Kestra HTTP API with a JDK `HttpServer` (same pattern as `TenantSyncTest`), removing the `FlowRepositoryInterface` in-process dependency
- Wires `MockKestraApiServer` into all test classes that call Kestra APIs; consolidates `kestraClient()` and `kestraUrl` into `AbstractCloningTask`
- Renames deprecated `io.kestra.core.tasks.log.Log` → `io.kestra.plugin.core.log.Log` and `io.kestra.core.tasks.flows.Subflow` → `io.kestra.plugin.core.flow.Subflow` across test YAML strings
- Bumps `kestra-api-client` to `1.0.11` and `inject-bom-versions` plugin to `1.0.4`
- Adds Testcontainers-based integration tests for `SyncFlows`, `SyncDashboards`, and `PushFlows`

## Test plan

- [ ] `TenantSyncTest` (2 tests, no GitHub dependency) — passes locally
- [ ] `SyncFlowTest` (5 tests) — requires `GH_PERSONAL_TOKEN` for the Git clone step; all Kestra API calls are mocked via JDK `HttpServer`
- [ ] Container tests (`SyncFlowsContainerTest`, `SyncDashboardsContainerTest`, `PushFlowsContainerTest`) — require Docker and a running Gitea instance
- [ ] Full CI run via `secrets: inherit` in `main.yml`

part-of: https://github.com/kestra-io/kestra-ee/issues/7011