### PR TITLE
docs: add GitHub PAT permissions to password property

### DIFF
--- a/src/main/java/io/kestra/plugin/git/AbstractGitTask.java
+++ b/src/main/java/io/kestra/plugin/git/AbstractGitTask.java
@@ -77,7 +77,13 @@ public abstract class AbstractGitTask extends Task {
 
     @Schema(
         title = "Password or personal access token",
-        description = "Supplies HTTP credentials. When a PAT is used, pushes are recorded under that PAT’s user without needing `authorName` and `authorEmail`."
+        description = """
+            Supplies HTTP credentials. When a PAT is used, pushes are recorded under that PAT’s user without needing `authorName` and `authorEmail`.
+
+            **GitHub PAT permissions required:**
+            - Fine-grained PAT: `Contents: Read` (clone/fetch) or `Contents: Read and Write` (push), plus `Metadata: Read` (mandatory base permission). Add `Workflows: Read and Write` when pushing `.github/workflows/` files.
+            - Classic PAT: `repo` scope covers all read/write operations; add `workflow` when pushing workflow files.
+            """
     )
     @PluginProperty(group = "connection")
     protected Property<String> password;


### PR DESCRIPTION
## Summary

- Documents required GitHub PAT permissions on the `password` schema property in `AbstractGitTask`
- Covers fine-grained PAT (`Contents`, `Metadata`, `Workflows`) and classic PAT (`repo`, `workflow`) scopes

## Test plan

- [ ] Verify rendered schema description looks correct in the Kestra UI / docs site