### PR TITLE
fix: use authorEmail as committer identity

### DIFF
--- a/src/main/java/io/kestra/plugin/git/AbstractPushTask.java
+++ b/src/main/java/io/kestra/plugin/git/AbstractPushTask.java
@@ -9,6 +9,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 
 import org.eclipse.jgit.api.AddCommand;
+import org.eclipse.jgit.api.CommitCommand;
 import org.eclipse.jgit.api.DiffCommand;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.EmptyCommitException;
@@ -318,12 +319,15 @@ public abstract class AbstractPushTask<O extends AbstractPushTask.Output> extend
 
                 String message = runContext.render(this.getCommitMessage()).as(String.class).orElse(null);
                 ObjectId head = git.getRepository().resolve(Constants.HEAD);
-                commit = git.commit()
+                PersonIdent author = author(runContext);
+                CommitCommand commitCommand = git.commit()
                     .setAllowEmpty(false)
                     .setMessage(message)
-                    .setAuthor(author(runContext))
-                    .call()
-                    .getId();
+                    .setAuthor(author);
+                if (author != null) {
+                    commitCommand.setCommitter(author);
+                }
+                commit = commitCommand.call().getId();
                 if (head == null) {
                     git.branchRename().setNewName(renderedBranch).call();
                 }

--- a/src/main/java/io/kestra/plugin/git/NamespaceSync.java
+++ b/src/main/java/io/kestra/plugin/git/NamespaceSync.java
@@ -18,6 +18,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.eclipse.jgit.api.AddCommand;
+import org.eclipse.jgit.api.CommitCommand;
 import org.eclipse.jgit.api.errors.EmptyCommitException;
 import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.ObjectId;
@@ -291,7 +292,11 @@ public class NamespaceSync extends AbstractCloningTask implements RunnableTask<N
                 }
 
                 PersonIdent author = author(runContext);
-                git.commit().setAllowEmpty(false).setMessage(rCommitMessage).setAuthor(author).call();
+                CommitCommand commitCommand = git.commit().setAllowEmpty(false).setMessage(rCommitMessage).setAuthor(author);
+                if (author != null) {
+                    commitCommand.setCommitter(author);
+                }
+                commitCommand.call();
 
                 Iterable<PushResult> results = this.authentified(git.push(), runContext).call();
                 for (PushResult pr : results) {

--- a/src/main/java/io/kestra/plugin/git/Push.java
+++ b/src/main/java/io/kestra/plugin/git/Push.java
@@ -8,6 +8,7 @@ import java.util.*;
 
 import org.apache.commons.io.FileUtils;
 import org.eclipse.jgit.api.AddCommand;
+import org.eclipse.jgit.api.CommitCommand;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.ListBranchCommand;
 import org.eclipse.jgit.api.RmCommand;
@@ -316,12 +317,15 @@ public class Push extends AbstractCloningTask implements RunnableTask<Push.Outpu
 
         ObjectId commitId = null;
         try {
-            commitId = git.commit()
+            PersonIdent author = author(runContext);
+            CommitCommand commitCommand = git.commit()
                 .setAllowEmpty(false)
                 .setMessage(runContext.render(this.commitMessage).as(String.class).orElse(null))
-                .setAuthor(author(runContext))
-                .call()
-                .getId();
+                .setAuthor(author);
+            if (author != null) {
+                commitCommand.setCommitter(author);
+            }
+            commitId = commitCommand.call().getId();
             authentified(git.push(), runContext).call();
         } catch (EmptyCommitException e) {
             logger.info("No changes to commit. Skipping push.");

--- a/src/main/java/io/kestra/plugin/git/TenantSync.java
+++ b/src/main/java/io/kestra/plugin/git/TenantSync.java
@@ -12,6 +12,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
 import org.eclipse.jgit.api.AddCommand;
+import org.eclipse.jgit.api.CommitCommand;
 import org.eclipse.jgit.api.errors.EmptyCommitException;
 import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.ObjectId;
@@ -310,7 +311,11 @@ public class TenantSync extends AbstractKestraTask implements RunnableTask<Tenan
 
             try {
                 PersonIdent author = author(runContext);
-                git.commit().setAllowEmpty(false).setMessage(rCommitMessage).setAuthor(author).call();
+                CommitCommand commitCommand = git.commit().setAllowEmpty(false).setMessage(rCommitMessage).setAuthor(author);
+                if (author != null) {
+                    commitCommand.setCommitter(author);
+                }
+                commitCommand.call();
 
                 Iterable<PushResult> results = this.authentified(git.push(), runContext).call();
                 for (PushResult pr : results) {

--- a/src/test/java/io/kestra/plugin/git/PushDahboardsTest.java
+++ b/src/test/java/io/kestra/plugin/git/PushDahboardsTest.java
@@ -218,6 +218,8 @@ public class PushDahboardsTest extends AbstractGitTest {
     private static void assertAuthor(RevCommit revCommit, String authorEmail, String authorName) {
         assertThat(revCommit.getAuthorIdent().getEmailAddress(), is(authorEmail));
         assertThat(revCommit.getAuthorIdent().getName(), is(authorName));
+        assertThat(revCommit.getCommitterIdent().getEmailAddress(), is(authorEmail));
+        assertThat(revCommit.getCommitterIdent().getName(), is(authorName));
     }
 
     private void deleteRemoteBranch(Path gitDirectory, String branchName) throws GitAPIException, IOException {

--- a/src/test/java/io/kestra/plugin/git/PushFlowsTest.java
+++ b/src/test/java/io/kestra/plugin/git/PushFlowsTest.java
@@ -778,6 +778,8 @@ public class PushFlowsTest extends AbstractGitTest {
     private static void assertAuthor(RevCommit revCommit, String authorEmail, String authorName) {
         assertThat(revCommit.getAuthorIdent().getEmailAddress(), is(authorEmail));
         assertThat(revCommit.getAuthorIdent().getName(), is(authorName));
+        assertThat(revCommit.getCommitterIdent().getEmailAddress(), is(authorEmail));
+        assertThat(revCommit.getCommitterIdent().getName(), is(authorName));
     }
 
     private static void assertDiffs(RunContext runContext, URI diffFileUri, List<Map<String, String>> expectedDiffs) throws IOException {

--- a/src/test/java/io/kestra/plugin/git/PushNamespaceFilesTest.java
+++ b/src/test/java/io/kestra/plugin/git/PushNamespaceFilesTest.java
@@ -650,6 +650,8 @@ public class PushNamespaceFilesTest extends AbstractGitTest {
     private static void assertAuthor(RevCommit revCommit, String authorEmail, String authorName) {
         assertThat(revCommit.getAuthorIdent().getEmailAddress(), is(authorEmail));
         assertThat(revCommit.getAuthorIdent().getName(), is(authorName));
+        assertThat(revCommit.getCommitterIdent().getEmailAddress(), is(authorEmail));
+        assertThat(revCommit.getCommitterIdent().getName(), is(authorName));
     }
 
     private static void assertDiffs(RunContext runContext, URI diffFileUri, List<Map<String, String>> expectedDiffs) throws IOException {


### PR DESCRIPTION
Pylon ticket: https://app.usepylon.com/support/issues/views/36469f3c-64a7-47dc-8e82-9d36026bfc31?issueNumber=1721&view=fs