### PR TITLE
fix: do not filter files when gitDirectory name contains ".git"

### DIFF
--- a/src/main/java/io/kestra/plugin/git/AbstractSyncTask.java
+++ b/src/main/java/io/kestra/plugin/git/AbstractSyncTask.java
@@ -89,6 +89,8 @@ public abstract class AbstractSyncTask<T, O extends AbstractSyncTask.Output> ext
         return syncDirectory;
     }
 
+    private static final List<String> PATH_TO_IGNORE = List.of(".git", ".gitignore", ".gitkeep");
+
     protected Map<URI, Supplier<InputStream>> gitResourcesContentByUri(Path baseDirectory, RunContext runContext) throws IOException, IllegalVariableEvaluationException {
         try (
             Stream<Path> paths = Files.walk(
@@ -100,7 +102,7 @@ public abstract class AbstractSyncTask<T, O extends AbstractSyncTask.Output> ext
             Stream<Path> filtered = paths.skip(1);
             KestraIgnore kestraIgnore = new KestraIgnore(baseDirectory);
             filtered = filtered.filter(path -> !kestraIgnore.isIgnoredFile(path.toString(), true));
-            filtered = filtered.filter(path -> !path.toString().contains(".git"));
+            filtered = filtered.filter(path -> PATH_TO_IGNORE.stream().noneMatch(ext -> path.toString().endsWith(ext)));
 
             return filtered.collect(
                 Collectors.toMap(

--- a/src/test/java/io/kestra/plugin/git/SyncNamespaceFilesTest.java
+++ b/src/test/java/io/kestra/plugin/git/SyncNamespaceFilesTest.java
@@ -3,6 +3,7 @@ package io.kestra.plugin.git;
 import java.io.*;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -241,6 +242,57 @@ public class SyncNamespaceFilesTest extends AbstractGitTest {
             is("UNCHANGED")
         );
     }
+
+    /**
+     * unit test to reproduce <a href="https://github.com/kestra-io/kestra-ee/issues/6402">...</a>
+     */
+    @Test
+    void syncWithDotGitInDirectoryName_ShouldSyncFiles() throws Exception {
+        String specialGitDir = "to_clone.github_files";
+        String expectedFile  = "hello.txt";
+
+        Path repoDir = Files.createTempDirectory("unit-test.special-dir-repo");
+        try (org.eclipse.jgit.api.Git git = org.eclipse.jgit.api.Git.init()
+            .setDirectory(repoDir.toFile())
+            .call()) {
+
+            Path specialDir = repoDir.resolve(specialGitDir);
+            Files.createDirectories(specialDir);
+            Files.writeString(specialDir.resolve(expectedFile), "hello");
+
+            git.add().addFilepattern(".").call();
+            git.commit()
+                .setMessage("test commit")
+                .setAuthor("test", "test@test.com")
+                .call();
+        }
+
+        RunContext runContext = runContextFactory.of(Map.of(
+            "flow", Map.of("tenantId", TENANT_ID, "namespace", "system"),
+            "url",          repoDir.toUri().toString(),
+            "pat",          "",
+            "branch",       "master",            // git init default
+            "namespace",    NAMESPACE,
+            "gitDirectory", specialGitDir
+        ));
+
+        SyncNamespaceFiles task = SyncNamespaceFiles.builder()
+            .url(Property.ofExpression("{{url}}"))
+            .branch(Property.ofExpression("{{branch}}"))
+            .gitDirectory(Property.ofExpression("{{gitDirectory}}"))
+            .namespace(Property.ofExpression("{{namespace}}"))
+            .build();
+
+        task.run(runContext);
+
+        assertThat(
+            runContext.storage().namespace(NAMESPACE).exists(Path.of(expectedFile)),
+            is(true)
+        );
+
+    }
+
+
 
     private static List<Map<String, String>> defaultCaseDiffs(boolean withDeleted) {
         ArrayList<Map<String, String>> diffs = new ArrayList<>(


### PR DESCRIPTION
## Summary

- Fixes [kestra-ee#6402](https://github.com/kestra-io/kestra-ee/issues/6402): `Sync*` tasks silently produced an empty diff when `gitDirectory` (or any ancestor in its absolute path) contained the substring `.git` — e.g. `solutions.github_integration/files`.
- Root cause: `AbstractSyncTask.gitResourcesContentByUri()` filtered walked paths with `path.toString().contains(".git")` against the full absolute path, so any ancestor whose name contained `.git` as a substring caused every descendant to be dropped.
- Replaces the substring match with `endsWith(".git")` so only paths terminating in `.git` are excluded.
- Adds a regression test `syncWithDotGitInDirectoryName_ShouldSyncFiles` that initializes a local git repo containing a directory named `to_clone.github_files`, runs `SyncNamespaceFiles`, and asserts the inner file is synced.

## Test plan

- [ ] `./gradlew test --tests "io.kestra.plugin.git.SyncNamespaceFilesTest.syncWithDotGitInDirectoryName_ShouldSyncFiles"` — passes
- [ ] `./gradlew test --tests "io.kestra.plugin.git.SyncNamespaceFilesTest"` — full suite still green
- [ ] Manual: run a flow with `gitDirectory: solutions.github_integration/files` and confirm files are synced into the namespace
