### PR TITLE
fix(NamespaceSync): remove namespace existence check based on flow repository

### DIFF
--- a/src/main/java/io/kestra/plugin/git/NamespaceSync.java
+++ b/src/main/java/io/kestra/plugin/git/NamespaceSync.java
@@ -35,7 +35,6 @@ import io.kestra.core.models.flows.FlowSource;
 import io.kestra.core.models.flows.FlowWithSource;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
-import io.kestra.core.repositories.FlowRepositoryInterface;
 import io.kestra.core.runners.DefaultRunContext;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.serializers.YamlParser;
@@ -228,12 +227,7 @@ public class NamespaceSync extends AbstractCloningTask implements RunnableTask<N
 
         runContext.logger().info("Now in NamespaceSync for namespace {}", rNamespace);
 
-        var flowRepository = ((DefaultRunContext) runContext).services().additionalService(FlowRepositoryInterface.class);
         var tenantId = runContext.flowInfo().tenantId();
-        var distinctNamespaces = flowRepository.findDistinctNamespace(tenantId);
-        if (!distinctNamespaces.contains(rNamespace)) {
-            throw new IllegalArgumentException("The namespace does not exist in the '" + tenantId + "' tenant.");
-        }
 
         var rGitDirectory = runContext.render(this.gitDirectory).as(String.class).orElse(null);
         var rSourceOfTruth = runContext.render(this.sourceOfTruth).as(SourceOfTruth.class).orElse(SourceOfTruth.KESTRA);


### PR DESCRIPTION
## Summary

- `NamespaceSync` called `flowRepository.findDistinctNamespace()` immediately after logging `Now in NamespaceSync for namespace` to guard against unknown namespaces
- That method only returns namespaces that have at least one flow — so any namespace containing **only namespace files** (no flows) was silently rejected at that point with no actionable error surfaced to the user
- Dropping the guard is safe: the downstream `planFlows` / `planNamespaceFiles` logic already handles missing entries correctly according to the configured `whenMissingInSource` policy, and an empty namespace produces a natural empty diff

## Root cause

```java
// Before — incorrect: findDistinctNamespace is flow-only
var distinctNamespaces = flowRepository.findDistinctNamespace(tenantId);
if (!distinctNamespaces.contains(rNamespace)) {
    throw new IllegalArgumentException("The namespace does not exist...");
}
```

## Test plan

- [ ] Run `NamespaceSync` against a namespace that has **only namespace files** (no flows) — task should complete successfully and produce an empty diff
- [ ] Run `NamespaceSync` against a namespace that has both flows and namespace files — behaviour unchanged
- [ ] Run `NamespaceSync` with `sourceOfTruth: GIT` pointing to a namespace directory in Git — files are synced into Kestra regardless of whether the namespace had prior flows