### PR TITLE
fix: replace system namespace in examples and clarify dotted-namespace folder layout

### DIFF
--- a/src/main/java/io/kestra/plugin/git/NamespaceSync.java
+++ b/src/main/java/io/kestra/plugin/git/NamespaceSync.java
@@ -61,7 +61,7 @@ import io.kestra.core.models.annotations.PluginProperty;
 @NoArgsConstructor
 @Schema(
     title = "Sync a namespace with Git",
-    description = "Syncs flows and Namespace Files for a single namespace between Git and Kestra. Direction is controlled by `sourceOfTruth`; deletions follow `whenMissingInSource` and respect `protectedNamespaces`. Supports dry-run diff output and optional subdirectory via `gitDirectory`."
+    description = "Syncs flows and Namespace Files for a single namespace between Git and Kestra. Direction is controlled by `sourceOfTruth`; deletions follow `whenMissingInSource` and respect `protectedNamespaces`. Supports dry-run diff output and optional subdirectory via `gitDirectory`. The flow containing this task does not need to live in the same namespace as the one being synced."
 )
 @Plugin(
     priority = Plugin.Priority.SECONDARY,
@@ -71,11 +71,11 @@ import io.kestra.core.models.annotations.PluginProperty;
             full = true,
             code = """
                 id: git_namespace_sync
-                namespace: system
+                namespace: company.ops
                 tasks:
                   - id: sync
                     type: io.kestra.plugin.git.NamespaceSync
-                    namespace: system
+                    namespace: company.ops
                     sourceOfTruth: GIT
                     whenMissingInSource: DELETE
                     protectedNamespaces:
@@ -92,11 +92,11 @@ import io.kestra.core.models.annotations.PluginProperty;
             full = true,
             code = """
                 id: kestra_namespace_sync
-                namespace: system
+                namespace: company.ops
                 tasks:
                   - id: sync
                     type: io.kestra.plugin.git.NamespaceSync
-                    namespace: system
+                    namespace: company.ops
                     sourceOfTruth: KESTRA
                     whenMissingInSource: KEEP
                     protectedNamespaces:
@@ -141,14 +141,28 @@ public class NamespaceSync extends AbstractCloningTask implements RunnableTask<N
 
     @Schema(
         title = "Git base directory",
-        description = "Optional subfolder in the repo; default is repo root. Within it, files are expected under `<namespace>/flows` and `<namespace>/files`."
+        description = """
+            Optional subfolder in the repo; default is repo root. Within it, files are expected under `<namespace>/flows` and `<namespace>/files`.
+
+            | gitDirectory | namespace    | Expected Git path                     |
+            | ------------ | ------------ | ------------------------------------- |
+            | (not set)    | company      | company/flows/my-flow.yaml            |
+            | monorepo     | company.ops  | monorepo/company.ops/flows/flow.yaml  |
+            | projectA     | company.team | projectA/company.team/flows/flow.yaml |
+
+            Note: a dotted namespace such as `company.team` maps to a folder **literally named `company.team`**, not to a nested `company/team` path."""
     )
     @PluginProperty(group = "destination")
     private Property<String> gitDirectory;
 
     @Schema(
         title = "Namespace to sync",
-        description = "Required; syncs only this namespace (no child namespaces)."
+        description = """
+            Required; syncs only this namespace (no child namespaces).
+
+            The namespace **must already exist** in the target Kestra instance before the sync runs — \
+            there is no automatic creation. If you are deploying to a fresh instance (e.g. preprod → Git → prod), \
+            create the namespace manually in prod first, then run this task with `sourceOfTruth: GIT`."""
     )
     @NotNull
     @PluginProperty(group = "main")

--- a/src/main/java/io/kestra/plugin/git/PushFlows.java
+++ b/src/main/java/io/kestra/plugin/git/PushFlows.java
@@ -45,7 +45,7 @@ import static io.kestra.core.utils.Rethrow.*;
             full = true,
             code = """
                 id: push_to_git
-                namespace: system
+                namespace: company.ops
 
                 tasks:
                   - id: commit_and_push
@@ -73,7 +73,7 @@ import static io.kestra.core.utils.Rethrow.*;
             full = true,
             code = """
                 id: git_push
-                namespace: system
+                namespace: company.ops
 
                 tasks:
                   - id: push

--- a/src/main/java/io/kestra/plugin/git/PushNamespaceFiles.java
+++ b/src/main/java/io/kestra/plugin/git/PushNamespaceFiles.java
@@ -42,7 +42,7 @@ import static io.kestra.core.utils.Rethrow.throwSupplier;
             full = true,
             code = """
                 id: push_to_git
-                namespace: system
+                namespace: company.ops
 
                 tasks:
                   - id: commit_and_push
@@ -67,7 +67,7 @@ import static io.kestra.core.utils.Rethrow.throwSupplier;
             full = true,
             code = """
                 id: git_push
-                namespace: system
+                namespace: company.ops
 
                 tasks:
                   - id: push

--- a/src/main/java/io/kestra/plugin/git/SyncFlow.java
+++ b/src/main/java/io/kestra/plugin/git/SyncFlow.java
@@ -42,7 +42,7 @@ import io.kestra.core.models.annotations.PluginProperty;
             full = true,
             code = """
                 id: sync_single_flow_from_git
-                namespace: system.cicd
+                namespace: company.ops
 
                 tasks:
                   - id: sync_my_flow

--- a/src/main/java/io/kestra/plugin/git/SyncFlows.java
+++ b/src/main/java/io/kestra/plugin/git/SyncFlows.java
@@ -46,7 +46,7 @@ import io.kestra.core.models.annotations.PluginProperty;
             full = true,
             code = """
                 id: sync_flows_from_git
-                namespace: system
+                namespace: company.ops
 
                 tasks:
                   - id: git
@@ -72,7 +72,7 @@ import io.kestra.core.models.annotations.PluginProperty;
             full = true,
             code = """
                 id: git_sync
-                namespace: system
+                namespace: company.ops
 
                 tasks:
                   - id: sync

--- a/src/main/java/io/kestra/plugin/git/SyncNamespaceFiles.java
+++ b/src/main/java/io/kestra/plugin/git/SyncNamespaceFiles.java
@@ -39,7 +39,7 @@ import io.kestra.core.models.annotations.PluginProperty;
             full = true,
             code = """
                 id: sync_from_git
-                namespace: system
+                namespace: company.ops
 
                 tasks:
                   - id: git
@@ -64,7 +64,7 @@ import io.kestra.core.models.annotations.PluginProperty;
             full = true,
             code = """
                 id: git_sync
-                namespace: system
+                namespace: company.ops
 
                 tasks:
                   - id: sync

--- a/src/main/java/io/kestra/plugin/git/TenantSync.java
+++ b/src/main/java/io/kestra/plugin/git/TenantSync.java
@@ -62,7 +62,7 @@ import io.kestra.core.models.annotations.PluginProperty;
             full = true,
             code = """
                 id: tenant_sync_git
-                namespace: system
+                namespace: company.ops
                 tasks:
                   - id: sync
                     type: io.kestra.plugin.git.TenantSync
@@ -86,7 +86,7 @@ import io.kestra.core.models.annotations.PluginProperty;
             full = true,
             code = """
                 id: tenant_sync_kestra
-                namespace: system
+                namespace: company.ops
                 tasks:
                   - id: sync
                     type: io.kestra.plugin.git.TenantSync
@@ -133,7 +133,16 @@ public class TenantSync extends AbstractKestraTask implements RunnableTask<Tenan
 
     @Schema(
         title = "Git base directory",
-        description = "Optional subfolder in the repo; default is repo root. Within it, namespaces are under `<namespace>/flows` and `<namespace>/files`, dashboards under `_global/dashboards`."
+        description = """
+            Optional subfolder in the repo; default is repo root. Within it, namespaces are under `<namespace>/flows` and `<namespace>/files`, dashboards under `_global/dashboards`.
+
+            | gitDirectory | namespace    | Expected Git path                     |
+            | ------------ | ------------ | ------------------------------------- |
+            | (not set)    | company      | company/flows/my-flow.yaml            |
+            | monorepo     | company.ops  | monorepo/company.ops/flows/flow.yaml  |
+            | projectA     | company.team | projectA/company.team/flows/flow.yaml |
+
+            Note: a dotted namespace such as `company.team` maps to a folder **literally named `company.team`**, not to a nested `company/team` path."""
     )
     @PluginProperty(group = "destination")
     private Property<String> gitDirectory;


### PR DESCRIPTION
## Summary

- Replace `namespace: system` (and `system.cicd`) in all flow examples across `NamespaceSync`, `TenantSync`, `PushFlows`, `PushNamespaceFiles`, `SyncFlow`, `SyncFlows`, and `SyncNamespaceFiles` with `company.ops` — users should not be guided to place flows in the protected `system` namespace.
- Add a namespace-to-Git-path mapping table and an explicit note to the `gitDirectory` schema description in `NamespaceSync` and `TenantSync` clarifying that a dotted namespace like `company.team` maps to a folder **literally named `company.team`**, not a nested `company/team` path.

## Test plan

- [ ] Review changed example YAML snippets: all flow-level `namespace:` fields now use `company.ops`; task-level `namespace: system` params and `protectedNamespaces: - system` entries are untouched
- [ ] Review `gitDirectory` schema descriptions in `NamespaceSync` and `TenantSync`: table present, dot-namespace note present