### PR TITLE
fix: build against kestra-api-client 1.3.2 (2.0.0-rc9)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ dependencies {
     api "org.eclipse.jgit:org.eclipse.jgit.http.apache:7.6.0.202603022253-r"
 
     // kestra API client
-    implementation "io.kestra:kestra-api-client:1.0.11"
+    implementation "io.kestra:kestra-api-client:1.3.2"
 }
 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 version=2.0.12-SNAPSHOT
-kestraVersion=2.0.0-SNAPSHOT
+kestraVersion=2.0.0-rc9

--- a/lombok.config
+++ b/lombok.config
@@ -3,3 +3,4 @@ lombok.addLombokGeneratedAnnotation = true
 lombok.anyConstructor.addConstructorProperties = true
 lombok.equalsAndHashCode.callSuper = call
 lombok.tostring.callsuper = call
+lombok.jacksonized.jacksonVersion += 2

--- a/src/main/java/io/kestra/plugin/git/NamespaceSync.java
+++ b/src/main/java/io/kestra/plugin/git/NamespaceSync.java
@@ -33,18 +33,18 @@ import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.exceptions.KestraRuntimeException;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.flows.FlowWithSource;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.serializers.YamlParser;
 import io.kestra.core.storages.NamespaceFile;
-import io.kestra.sdk.KestraClient;
+import io.kestra.plugin.git.services.GitService;
 import io.kestra.sdk.internal.ApiException;
 import io.kestra.sdk.model.QueryFilter;
 import io.kestra.sdk.model.QueryFilterField;
 import io.kestra.sdk.model.QueryFilterOp;
-import io.kestra.plugin.git.services.GitService;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Nullable;
@@ -55,7 +55,6 @@ import lombok.experimental.SuperBuilder;
 import static io.kestra.core.utils.Rethrow.throwConsumer;
 import static java.lang.Integer.MAX_VALUE;
 import static org.eclipse.jgit.transport.RemoteRefUpdate.Status.*;
-import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder(toBuilder = true)
 @ToString
@@ -368,7 +367,7 @@ public class NamespaceSync extends AbstractCloningTask implements RunnableTask<N
                                     throw new FlowProcessingException(flowValidated.getConstraints());
                                 }
                                 var flowId = YamlParser.parse(gitNode.rawYaml, io.kestra.core.models.flows.Flow.class).getId();
-                                kestraClient.flows().importFlows(false, tenant, toNamedTempFile(flowId + ".yaml", gitNode.rawYaml));
+                                kestraClient.flows().importFlows(tenant, false, toNamedTempFile(flowId + ".yaml", gitNode.rawYaml));
                             } catch (Exception e) {
                                 handleInvalid(rc, rInvalid, "FLOW " + key, e);
                             }
@@ -414,7 +413,8 @@ public class NamespaceSync extends AbstractCloningTask implements RunnableTask<N
                                 {
                                     try {
                                         kestraClient(rc).flows().deleteFlow(
-                                            kestraFlowWithSource.getNamespace(), kestraFlowWithSource.getId(), tenant);
+                                            kestraFlowWithSource.getNamespace(), kestraFlowWithSource.getId(), tenant
+                                        );
                                     } catch (ApiException | IllegalVariableEvaluationException e) {
                                         handleInvalid(rc, rInvalid, "FLOW " + key, e);
                                     }
@@ -443,7 +443,7 @@ public class NamespaceSync extends AbstractCloningTask implements RunnableTask<N
                                     throw new FlowProcessingException(flowValidated.getConstraints());
                                 }
                                 var flowId = YamlParser.parse(gitNode.rawYaml, io.kestra.core.models.flows.Flow.class).getId();
-                                kestraClient.flows().importFlows(false, tenant, toNamedTempFile(flowId + ".yaml", gitNode.rawYaml));
+                                kestraClient.flows().importFlows(tenant, false, toNamedTempFile(flowId + ".yaml", gitNode.rawYaml));
                             } catch (Exception e) {
                                 handleInvalid(rc, rInvalid, "FLOW " + key, e);
                             }

--- a/src/main/java/io/kestra/plugin/git/PushDashboards.java
+++ b/src/main/java/io/kestra/plugin/git/PushDashboards.java
@@ -25,12 +25,11 @@ import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.kestra.sdk.KestraClient;
 import io.kestra.sdk.internal.ApiClient;
-import io.kestra.sdk.model.PagedResultsDashboard;
+import io.kestra.sdk.model.PagedResultsDashboardControllerDashboardResponse;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
-
 
 @SuperBuilder(toBuilder = true)
 @ToString
@@ -123,13 +122,13 @@ public class PushDashboards extends AbstractPushTask<PushDashboards.Output> {
         String tenantId = flowProps.get("tenantId");
         KestraClient kestraClient = kestraClient(runContext);
 
-        List<io.kestra.sdk.model.Dashboard> allDashboards = new ArrayList<>();
+        List<io.kestra.sdk.model.DashboardControllerDashboardResponse> allDashboards = new ArrayList<>();
         int page = 1;
         int size = 200;
-        PagedResultsDashboard pagedResults;
+        PagedResultsDashboardControllerDashboardResponse pagedResults;
         do {
             try {
-                pagedResults = kestraClient.dashboards().searchDashboards(page, size, tenantId, null, null);
+                pagedResults = kestraClient.dashboards().searchDashboards(tenantId, page, size, null, null);
             } catch (Exception e) {
                 throw new KestraRuntimeException("Failed to fetch dashboards from Kestra", e);
             }
@@ -137,7 +136,7 @@ public class PushDashboards extends AbstractPushTask<PushDashboards.Output> {
             page++;
         } while (pagedResults.getResults().size() == size);
 
-        Stream<io.kestra.sdk.model.Dashboard> dashboardStream = allDashboards.stream();
+        Stream<io.kestra.sdk.model.DashboardControllerDashboardResponse> dashboardStream = allDashboards.stream();
         if (globs != null) {
             List<PathMatcher> matchers = globs.stream().map(glob -> FileSystems.getDefault().getPathMatcher("glob:" + glob)).toList();
             dashboardStream = dashboardStream.filter(dashboard ->
@@ -147,19 +146,21 @@ public class PushDashboards extends AbstractPushTask<PushDashboards.Output> {
             });
         }
 
-        return dashboardStream.collect(Collectors.toMap(
-            dashboard -> flowDirectory.resolve(dashboard.getId() + ".yml"),
-            dashboard -> () ->
-            {
-                try {
-                    String sourceCode = fetchDashboardSourceCode(kestraClient, runContext, tenantId, dashboard.getId());
-                    String cleanSourceCode = sourceCode.replaceAll("(?m)^updated:.*\\R?", "");
-                    return new ByteArrayInputStream(cleanSourceCode.getBytes(StandardCharsets.UTF_8));
-                } catch (Exception e) {
-                    throw new KestraRuntimeException("Failed to fetch dashboard source for " + dashboard.getId(), e);
+        return dashboardStream.collect(
+            Collectors.toMap(
+                dashboard -> flowDirectory.resolve(dashboard.getId() + ".yml"),
+                dashboard -> () ->
+                {
+                    try {
+                        String sourceCode = fetchDashboardSourceCode(kestraClient, runContext, tenantId, dashboard.getId());
+                        String cleanSourceCode = sourceCode.replaceAll("(?m)^updated:.*\\R?", "");
+                        return new ByteArrayInputStream(cleanSourceCode.getBytes(StandardCharsets.UTF_8));
+                    } catch (Exception e) {
+                        throw new KestraRuntimeException("Failed to fetch dashboard source for " + dashboard.getId(), e);
+                    }
                 }
-            }
-        ));
+            )
+        );
     }
 
     private String fetchDashboardSourceCode(KestraClient kestraClient, RunContext runContext, String tenantId, String dashboardId) throws Exception {
@@ -174,7 +175,8 @@ public class PushDashboards extends AbstractPushTask<PushDashboards.Output> {
             Collections.emptyList(), Collections.emptyList(), null,
             null, Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
             "application/json", null, new String[0],
-            new TypeReference<Map<String, Object>>() {}
+            new TypeReference<Map<String, Object>>() {
+            }
         );
         return (String) response.get("sourceCode");
     }

--- a/src/main/java/io/kestra/plugin/git/Sync.java
+++ b/src/main/java/io/kestra/plugin/git/Sync.java
@@ -20,10 +20,10 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 
-import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.exceptions.KestraRuntimeException;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.flows.FlowWithSource;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
@@ -49,7 +49,6 @@ import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 
 import static io.kestra.core.utils.Rethrow.*;
-import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder(toBuilder = true)
 @ToString
@@ -184,7 +183,7 @@ public class Sync extends AbstractCloningTask implements RunnableTask<VoidOutput
                         flowWithSource = FlowWithSource.builder().source(flowSource).id(flowId).build();
                     } else {
                         String flowId = YamlParser.parse(flowSource, io.kestra.core.models.flows.Flow.class).getId();
-                        kestraClient.flows().importFlows(false, tenantId, toNamedTempFile(flowId + ".yaml", flowSource.stripTrailing()));
+                        kestraClient.flows().importFlows(tenantId, false, toNamedTempFile(flowId + ".yaml", flowSource.stripTrailing()));
                         // Determine addition vs update by checking if revision == 1
                         var imported = fetchSingleFlow(kestraClient, tenantId, flowSourceByNamespace.getKey(), flowId);
                         isAddition = imported != null && imported.getRevision() != null && imported.getRevision() == 1;

--- a/src/main/java/io/kestra/plugin/git/SyncDashboards.java
+++ b/src/main/java/io/kestra/plugin/git/SyncDashboards.java
@@ -9,25 +9,25 @@ import java.time.Instant;
 import java.util.*;
 import java.util.regex.Pattern;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import org.apache.commons.io.IOUtils;
 
-import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import com.fasterxml.jackson.core.type.TypeReference;
+
 import io.kestra.core.exceptions.KestraRuntimeException;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.dashboards.Dashboard;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.serializers.YamlParser;
 import io.kestra.sdk.KestraClient;
 import io.kestra.sdk.internal.ApiClient;
-import io.kestra.sdk.model.PagedResultsDashboard;
+import io.kestra.sdk.model.PagedResultsDashboardControllerDashboardResponse;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
-import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder(toBuilder = true)
 @ToString
@@ -149,7 +149,8 @@ public class SyncDashboards extends AbstractSyncTask<Dashboard, SyncDashboards.O
         } else {
             // Skip createDashboard if content is unchanged to preserve the updated timestamp
             // (UNCHANGED detection in wrapper() compares before/after updated timestamps)
-            boolean contentChanged = prevDashboard.map(previous -> {
+            boolean contentChanged = prevDashboard.map(previous ->
+            {
                 String prevSource = previous.getSourceCode() != null ? previous.getSourceCode() : "";
                 return !prevSource.replace("\r\n", "\n").strip().equals(dashboardSource.replace("\r\n", "\n").strip());
             }).orElse(true);
@@ -174,18 +175,20 @@ public class SyncDashboards extends AbstractSyncTask<Dashboard, SyncDashboards.O
             KestraClient kestraClient = kestraClient(runContext);
             int page = 1;
             int size = 200;
-            PagedResultsDashboard pagedResults;
+            PagedResultsDashboardControllerDashboardResponse pagedResults;
             do {
-                pagedResults = kestraClient.dashboards().searchDashboards(page, size, tenantId, null, null);
+                pagedResults = kestraClient.dashboards().searchDashboards(tenantId, page, size, null, null);
                 for (var sdkDash : pagedResults.getResults()) {
                     if (dashboardId.equals(sdkDash.getId())) {
                         // Fetch YAML source via raw HTTP call
                         String sourceCode = fetchDashboardSourceCode(kestraClient, runContext, tenantId, dashboardId);
-                        Dashboard parsed = YamlParser.parse(sourceCode, Dashboard.class);  // preserves getUpdated() from updated: injection
-                        return Optional.of(parsed.toBuilder()
-                            .tenantId(tenantId)
-                            .sourceCode(sourceCode.replaceAll("(?m)^updated:.*\\R?", ""))
-                            .build());
+                        Dashboard parsed = YamlParser.parse(sourceCode, Dashboard.class); // preserves getUpdated() from updated: injection
+                        return Optional.of(
+                            parsed.toBuilder()
+                                .tenantId(tenantId)
+                                .sourceCode(sourceCode.replaceAll("(?m)^updated:.*\\R?", ""))
+                                .build()
+                        );
                     }
                 }
                 page++;
@@ -235,17 +238,19 @@ public class SyncDashboards extends AbstractSyncTask<Dashboard, SyncDashboards.O
             List<Dashboard> dashboards = new ArrayList<>();
             int page = 1;
             int size = 200;
-            PagedResultsDashboard pagedResults;
+            PagedResultsDashboardControllerDashboardResponse pagedResults;
             do {
-                pagedResults = kestraClient.dashboards().searchDashboards(page, size, tenantId, null, null);
+                pagedResults = kestraClient.dashboards().searchDashboards(tenantId, page, size, null, null);
                 for (var sdkDash : pagedResults.getResults()) {
                     try {
                         String sourceCode = fetchDashboardSourceCode(kestraClient, runContext, tenantId, sdkDash.getId());
                         Dashboard parsed = YamlParser.parse(sourceCode, Dashboard.class);
-                        dashboards.add(parsed.toBuilder()
-                            .tenantId(tenantId)
-                            .sourceCode(sourceCode.replaceAll("(?m)^updated:.*\\R?", ""))
-                            .build());
+                        dashboards.add(
+                            parsed.toBuilder()
+                                .tenantId(tenantId)
+                                .sourceCode(sourceCode.replaceAll("(?m)^updated:.*\\R?", ""))
+                                .build()
+                        );
                     } catch (Exception e) {
                         runContext.logger().warn("Skipping dashboard {} — failed to fetch source: {}", sdkDash.getId(), e.getMessage());
                     }
@@ -270,7 +275,8 @@ public class SyncDashboards extends AbstractSyncTask<Dashboard, SyncDashboards.O
             Collections.emptyList(), Collections.emptyList(), null,
             null, Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
             "application/json", null, new String[0],
-            new TypeReference<Map<String, Object>>() {}
+            new TypeReference<Map<String, Object>>() {
+            }
         );
         return (String) response.get("sourceCode");
     }

--- a/src/main/java/io/kestra/plugin/git/SyncFlow.java
+++ b/src/main/java/io/kestra/plugin/git/SyncFlow.java
@@ -12,6 +12,7 @@ import org.eclipse.jgit.api.Git;
 
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.RunContext;
@@ -24,7 +25,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
-import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder(toBuilder = true)
 @ToString
@@ -158,7 +158,7 @@ public class SyncFlow extends AbstractKestraTask implements RunnableTask<SyncFlo
             // Projected revision: existing + 1, or 1 for a new flow
             int projectedRevision;
             try {
-                FlowWithSource existing = kestraClient.flows().flow(renderedNamespace, flowId, false, false, tenantId, null);
+                FlowWithSource existing = kestraClient.flows().flow(renderedNamespace, flowId, tenantId, false, null, false);
                 projectedRevision = existing.getRevision() != null ? existing.getRevision() + 1 : 1;
             } catch (ApiException e) {
                 // Flow does not exist yet
@@ -172,10 +172,10 @@ public class SyncFlow extends AbstractKestraTask implements RunnableTask<SyncFlo
         } else {
             // Import the flow
             var tempFile = toNamedTempFile(flowId + ".yaml", flowSource.stripTrailing());
-            kestraClient.flows().importFlows(true, tenantId, tempFile);
+            kestraClient.flows().importFlows(tenantId, true, tempFile);
 
             // Fetch the saved flow to populate the output
-            result = kestraClient.flows().flow(renderedNamespace, flowId, false, false, tenantId, null);
+            result = kestraClient.flows().flow(renderedNamespace, flowId, tenantId, false, null, false);
         }
 
         git.close();

--- a/src/main/java/io/kestra/plugin/git/SyncFlows.java
+++ b/src/main/java/io/kestra/plugin/git/SyncFlows.java
@@ -21,6 +21,7 @@ import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.exceptions.KestraRuntimeException;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.FlowWithException;
 import io.kestra.core.models.flows.FlowWithSource;
@@ -37,7 +38,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
-import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder(toBuilder = true)
 @ToString
@@ -270,7 +270,7 @@ public class SyncFlows extends AbstractSyncTask<Flow, SyncFlows.Output> {
         }
 
         var parsedId = YamlParser.parse(flowSource, Flow.class).getId();
-        kestraClient.flows().importFlows(true, tenantId, toNamedTempFile(parsedId + ".yaml", flowSource.stripTrailing()));
+        kestraClient.flows().importFlows(tenantId, true, toNamedTempFile(parsedId + ".yaml", flowSource.stripTrailing()));
 
         // Re-fetch from Kestra to get the updated revision
         var parsedNamespace = YamlParser.parse(flowSource, Flow.class).getNamespace();

--- a/src/main/java/io/kestra/plugin/git/TenantSync.java
+++ b/src/main/java/io/kestra/plugin/git/TenantSync.java
@@ -21,12 +21,14 @@ import org.eclipse.jgit.lib.PersonIdent;
 import org.eclipse.jgit.transport.PushResult;
 import org.eclipse.jgit.transport.RemoteRefUpdate;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+
 import io.kestra.core.exceptions.FlowProcessingException;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.exceptions.KestraRuntimeException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.flows.FlowWithSource;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
@@ -46,7 +48,6 @@ import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 import static org.eclipse.jgit.transport.RemoteRefUpdate.Status.*;
-import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder(toBuilder = true)
 @ToString
@@ -254,7 +255,7 @@ public class TenantSync extends AbstractKestraTask implements RunnableTask<Tenan
         PagedResultsNamespace result;
         do {
             result = kestraClient.namespaces()
-                .searchNamespaces(page, size, false, tenantId, null, null, Map.of());
+                .searchNamespaces(tenantId, null, page, size, null, false);
             result.getResults().forEach(ns -> kestraNamespaces.add(ns.getId()));
             page++;
         } while (result.getResults().size() == size);
@@ -486,8 +487,8 @@ public class TenantSync extends AbstractKestraTask implements RunnableTask<Tenan
                                 }
 
                                 kestraClient.flows().importFlows(
-                                    OnInvalidSyntax.FAIL.equals(rOnInvalidSyntax),
                                     runContext.flowInfo().tenantId(),
+                                    OnInvalidSyntax.FAIL.equals(rOnInvalidSyntax),
                                     toNamedTempFile(flowId + ".yaml", gitYaml)
                                 );
                             } catch (Exception e) {
@@ -567,10 +568,9 @@ public class TenantSync extends AbstractKestraTask implements RunnableTask<Tenan
                                 }
 
                                 kestraClient.flows().importFlows(
-                                    OnInvalidSyntax.FAIL.equals(rOnInvalidSyntax),
                                     runContext.flowInfo().tenantId(),
-                                    toNamedTempFile(flowId + ".yaml", gitYaml),
-                                    Map.of()
+                                    OnInvalidSyntax.FAIL.equals(rOnInvalidSyntax),
+                                    toNamedTempFile(flowId + ".yaml", gitYaml)
                                 );
                             } catch (Exception e) {
                                 handleInvalid(runContext, rOnInvalidSyntax, "FLOW " + flowId, e);
@@ -852,10 +852,10 @@ public class TenantSync extends AbstractKestraTask implements RunnableTask<Tenan
 
             int page = 1;
             int size = 200;
-            PagedResultsDashboard pagedResults;
+            PagedResultsDashboardControllerDashboardResponse pagedResults;
 
             do {
-                pagedResults = kestraClient.dashboards().searchDashboards(page, size, runContext.flowInfo().tenantId(), null, null);
+                pagedResults = kestraClient.dashboards().searchDashboards(runContext.flowInfo().tenantId(), page, size, null, null);
 
                 String tenantForFetch = runContext.flowInfo().tenantId();
                 pagedResults.getResults().forEach(dash ->
@@ -1038,7 +1038,8 @@ public class TenantSync extends AbstractKestraTask implements RunnableTask<Tenan
             Collections.emptyList(), Collections.emptyList(), null,
             null, Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
             "application/json", null, new String[0],
-            new TypeReference<Map<String, Object>>() {}
+            new TypeReference<Map<String, Object>>() {
+            }
         );
         return (String) response.get("sourceCode");
     }

--- a/src/test/java/io/kestra/plugin/git/KestraContainerTestDataUtils.java
+++ b/src/test/java/io/kestra/plugin/git/KestraContainerTestDataUtils.java
@@ -1,6 +1,5 @@
 package io.kestra.plugin.git;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -34,7 +33,7 @@ public class KestraContainerTestDataUtils {
         var tmp = Files.createTempFile("kestra-flow-", ".yaml");
         try {
             Files.writeString(tmp, flowYaml, StandardCharsets.UTF_8);
-            kestraClient.flows().importFlows(false, tenantId, tmp.toFile());
+            kestraClient.flows().importFlows(tenantId, false, tmp.toFile());
         } finally {
             Files.deleteIfExists(tmp);
         }


### PR DESCRIPTION
## What

- Bumps `kestraVersion` to `2.0.0-rc9` (moved here from `main`).
- Migrates all SDK call sites to `kestra-api-client` 1.3.2, which the rc9 platform BOM enforces.
- Configures the Jackson variant for Lombok's `@Jacksonized`.

## Why

`./gradlew release -U` failed to compile: the 2.0.0-rc9 platform BOM enforces `kestra-api-client` 1.3.2 (the `1.0.11` entry in `build.gradle` is overridden by `enforcedPlatform`), and 1.3.2 renamed the dashboard models and moved `tenant` to the first parameter on several endpoints.

Separately, Lombok 1.18.44+ emits a warning on every `@Jacksonized` until the Jackson variant is chosen in `lombok.config`.

## How

SDK signature migration:

| Before | After |
| --- | --- |
| `PagedResultsDashboard` | `PagedResultsDashboardControllerDashboardResponse` |
| `sdk.model.Dashboard` | `DashboardControllerDashboardResponse` |
| `searchDashboards(page, size, tenant, …)` | `searchDashboards(tenant, page, size, q, sort)` |
| `importFlows(failOnError, tenant, file)` | `importFlows(tenant, failOnError, fileUpload)` |
| `searchNamespaces(page, size, existing, tenant, …, Map.of())` | `searchNamespaces(tenant, q, page, size, sort, existing)` |
| `flow(namespace, id, source, allowDeleted, tenant, revision)` | `flow(namespace, id, tenant, source, revision, allowDeleted)` |

Also drops a stale trailing `Map.of()` argument on one `importFlows` call in `TenantSync`.

The remaining all-`String` call sites (`validateFlows`, `deleteFlow`, `createDashboard`, `deleteDashboard`, `namespace`, `createNamespace`, `exportFlowsByQuery`, `listFlowsByNamespace`) were audited against 1.3.2 — their argument order already matches, so no silent tenant/id swaps remain.

`lombok.jacksonized.jacksonVersion` is a list key, so it needs `+=`. This project is on Jackson 2 (`com.fasterxml.jackson`).

## Tests

- `./gradlew build -x test` and `./gradlew javadoc` pass, with no `@Jacksonized` warnings.
- Container tests were not run locally (need Docker/Gitea) — relying on CI.