### PR TITLE
test: rename the no-plugins test image to slim

### DIFF
--- a/src/test/java/io/kestra/plugin/git/AbstractKestraContainerTest.java
+++ b/src/test/java/io/kestra/plugin/git/AbstractKestraContainerTest.java
@@ -24,7 +24,7 @@ public abstract class AbstractKestraContainerTest {
 
     @Container
     protected static final GenericContainer<?> KESTRA_CONTAINER = new GenericContainer<>(
-        DockerImageName.parse("kestra/kestra:develop-no-plugins")
+        DockerImageName.parse("kestra/kestra:develop-slim")
     )
         .withExposedPorts(8080)
         .withEnv("KESTRA_SECURITY_SUPER_ADMIN_USERNAME", USERNAME)


### PR DESCRIPTION
Part-of: https://github.com/kestra-io/kestra-ee/issues/6145

-slim replaces -no-plugins (kestra-io/kestra#16054, kestra-io/actions#204).

Ordering: merge after kestra-io/actions#204 has published a develop-slim OSS image; until then the deprecated develop-no-plugins alias keeps main green.