### PR TITLE
Recursive namespace sync + apiToken auth

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 version=3.0.1-SNAPSHOT
-kestraVersion=2.0.0-rc9
+kestraVersion=2.0.0-rc10

--- a/src/main/java/io/kestra/plugin/git/AbstractCloningTask.java
+++ b/src/main/java/io/kestra/plugin/git/AbstractCloningTask.java
@@ -15,16 +15,18 @@ import org.eclipse.jgit.transport.TagOpt;
 import org.slf4j.Logger;
 
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.SDK;
 import io.kestra.sdk.KestraClient;
+import io.kestra.sdk.internal.ApiException;
+import io.kestra.sdk.model.PagedResultsNamespace;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.jackson.Jacksonized;
-import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder(toBuilder = true)
 @NoArgsConstructor
@@ -56,7 +58,8 @@ public abstract class AbstractCloningTask extends AbstractGitTask {
 
     protected KestraClient kestraClient(RunContext runContext) throws IllegalVariableEvaluationException {
         String rKestraUrl = runContext.render(kestraUrl).as(String.class)
-            .orElseGet(() -> {
+            .orElseGet(() ->
+            {
                 try {
                     String rendered = runContext.render(KESTRA_URL_TEMPLATE);
                     return (rendered == null || rendered.isBlank()) ? DEFAULT_KESTRA_URL : rendered;
@@ -75,8 +78,15 @@ public abstract class AbstractCloningTask extends AbstractGitTask {
         var builder = KestraClient.builder().url(normalizedUrl);
 
         if (auth != null) {
+            Optional<String> maybeApiToken = runContext.render(auth.apiToken).as(String.class);
             Optional<String> maybeUsername = runContext.render(auth.username).as(String.class);
             Optional<String> maybePassword = runContext.render(auth.password).as(String.class);
+            if (maybeApiToken.isPresent() && (maybeUsername.isPresent() || maybePassword.isPresent())) {
+                throw new IllegalArgumentException("Use either apiToken or username/password for authentication, not both");
+            }
+            if (maybeApiToken.isPresent()) {
+                return builder.tokenAuth(maybeApiToken.get()).build();
+            }
             if (maybeUsername.isPresent() && maybePassword.isPresent()) {
                 return builder.basicAuth(maybeUsername.get(), maybePassword.get()).build();
             }
@@ -109,6 +119,34 @@ public abstract class AbstractCloningTask extends AbstractGitTask {
         return builder.build();
     }
 
+    protected List<String> descendantNamespaces(RunContext runContext, String tenantId, String namespace) throws IllegalVariableEvaluationException, ApiException {
+        var client = kestraClient(runContext);
+        List<String> out = new ArrayList<>();
+        int page = 1;
+        int size = 200;
+        List<io.kestra.sdk.model.Namespace> results;
+        do {
+            // q is a server-side contains filter, so prefix matches are never missed
+            PagedResultsNamespace result = client.namespaces().searchNamespaces(tenantId, namespace + ".", page, size, null, false);
+            results = result.getResults();
+            if (results == null) {
+                break;
+            }
+            results.forEach(ns ->
+            {
+                if (isDescendant(namespace, ns.getId())) {
+                    out.add(ns.getId());
+                }
+            });
+            page++;
+        } while (results.size() == size);
+        return out;
+    }
+
+    protected static boolean isDescendant(String rootNamespace, String namespace) {
+        return namespace != null && namespace.startsWith(rootNamespace + ".");
+    }
+
     @Builder
     @Getter
     @Jacksonized
@@ -120,6 +158,10 @@ public abstract class AbstractCloningTask extends AbstractGitTask {
         @Schema(title = "Password for HTTP Basic authentication.")
         @PluginProperty(secret = true, group = "connection")
         private Property<String> password;
+
+        @Schema(title = "API token for authentication.")
+        @PluginProperty(secret = true, group = "connection")
+        private Property<String> apiToken;
 
         @Schema(
             title = "Automatically retrieve credentials from Kestra's configuration if available",

--- a/src/main/java/io/kestra/plugin/git/NamespaceSync.java
+++ b/src/main/java/io/kestra/plugin/git/NamespaceSync.java
@@ -63,7 +63,7 @@ import static org.eclipse.jgit.transport.RemoteRefUpdate.Status.*;
 @NoArgsConstructor
 @Schema(
     title = "Sync a namespace with Git",
-    description = "Syncs flows and Namespace Files for a single namespace between Git and Kestra. Direction is controlled by `sourceOfTruth`; deletions follow `whenMissingInSource` and respect `protectedNamespaces`. Supports dry-run diff output and optional subdirectory via `gitDirectory`. The flow containing this task does not need to live in the same namespace as the one being synced. Flows saved as drafts are not synced to Git."
+    description = "Syncs flows and Namespace Files for a namespace (optionally including child namespaces via `includeChildNamespaces`) between Git and Kestra. Direction is controlled by `sourceOfTruth`; deletions follow `whenMissingInSource` and respect `protectedNamespaces`. Supports dry-run diff output and optional subdirectory via `gitDirectory`. The flow containing this task does not need to live in the same namespace as the one being synced. Flows saved as drafts are not synced to Git."
 )
 @Plugin(
     priority = Plugin.Priority.SECONDARY,
@@ -159,11 +159,19 @@ public class NamespaceSync extends AbstractCloningTask implements RunnableTask<N
 
     @Schema(
         title = "Namespace to sync",
-        description = "Required; syncs only this namespace (no child namespaces). The namespace is created automatically when it does not exist yet (e.g. when bootstrapping a fresh environment with `sourceOfTruth: GIT`)."
+        description = "Required; syncs only this namespace unless `includeChildNamespaces` is true. The namespace is created automatically when it does not exist yet (e.g. when bootstrapping a fresh environment with `sourceOfTruth: GIT`)."
     )
     @NotNull
     @PluginProperty(group = "main")
     private Property<String> namespace;
+
+    @Schema(
+        title = "Include child namespaces",
+        description = "Default false. When true, also syncs every descendant namespace of `namespace`."
+    )
+    @Builder.Default
+    @PluginProperty(group = "main")
+    private Property<Boolean> includeChildNamespaces = Property.ofValue(false);
 
     @Schema(
         title = "Source of truth",
@@ -253,32 +261,55 @@ public class NamespaceSync extends AbstractCloningTask implements RunnableTask<N
         var rOnInvalidSyntax = runContext.render(this.onInvalidSyntax).as(OnInvalidSyntax.class).orElse(OnInvalidSyntax.FAIL);
         var rProtectedNamespaces = runContext.render(this.protectedNamespaces).asList(String.class);
         var rCommitMessage = runContext.render(this.getCommitMessage()).as(String.class).orElse("Namespace sync from Kestra");
+        var rIncludeChildNamespaces = runContext.render(this.includeChildNamespaces).as(Boolean.class).orElse(false);
 
         var git = gitService.cloneBranch(runContext, rBranch, this.cloneSubmodules);
 
         var repoWorktree = git.getRepository().getWorkTree().toPath();
         var baseDir = (rGitDirectory == null || rGitDirectory.isBlank()) ? repoWorktree : repoWorktree.resolve(rGitDirectory);
 
-        // Read Git content (namespace-first) then filter to target namespace (no recursion)
+        // Read Git content (namespace-first) then filter to target namespace (and descendants when recursive)
         GitTree gitFlowsAll = readGitTreeNamespaceFirst(baseDir);
-        GitTree gitFlows = filterTreeByNamespace(gitFlowsAll, rNamespace);
 
-        // Read Git namespace files (<namespace>/files/**)
-        Map<String, byte[]> gitFiles = readGitNamespaceFiles(baseDir, rNamespace);
+        Set<String> syncNamespaces = new LinkedHashSet<>();
+        syncNamespaces.add(rNamespace);
+        if (rIncludeChildNamespaces) {
+            syncNamespaces.addAll(descendantNamespaces(runContext, tenantId, rNamespace));
+            if (rSourceOfTruth == SourceOfTruth.GIT) {
+                for (String gitNamespace : gitDescendantNamespaces(baseDir, rNamespace)) {
+                    if (syncNamespaces.contains(gitNamespace)) {
+                        continue;
+                    }
+                    if (!rDryRun) {
+                        try {
+                            kestraClient.namespaces().createNamespace(tenantId, new io.kestra.sdk.model.Namespace().id(gitNamespace));
+                        } catch (Exception e) {
+                            runContext.logger().warn("Skipping git namespace {}: could not create it in Kestra: {}", gitNamespace, e.getMessage());
+                            continue;
+                        }
+                    }
+                    syncNamespaces.add(gitNamespace);
+                }
+            }
+        }
+
+        GitTree gitFlows = filterTreeByNamespace(gitFlowsAll, syncNamespaces);
 
         if (rSourceOfTruth == SourceOfTruth.KESTRA) {
             ensureNamespaceFolders(baseDir, rNamespace);
         }
 
-        // Fetch Kestra state limited to target namespace only
-        KestraState kestraState = loadKestraState(runContext, rNamespace, rOnInvalidSyntax);
-        Map<String, byte[]> namespaceFiles = listNamespaceFiles(runContext, rNamespace);
+        KestraState kestraState = loadKestraState(runContext, rNamespace, rOnInvalidSyntax, rIncludeChildNamespaces, syncNamespaces);
 
         List<DiffLine> diffs = new ArrayList<>();
         List<Runnable> apply = new ArrayList<>();
 
         planFlows(runContext, baseDir, gitFlows, kestraState, rSourceOfTruth, rWhenMissingInSource, rOnInvalidSyntax, rProtectedNamespaces, rDryRun, diffs, apply);
-        planNamespaceFiles(runContext, baseDir, rNamespace, gitFiles, namespaceFiles, rSourceOfTruth, rWhenMissingInSource, rProtectedNamespaces, rDryRun, diffs, apply);
+        for (String fileNamespace : syncNamespaces) {
+            Map<String, byte[]> gitFiles = readGitNamespaceFiles(baseDir, fileNamespace);
+            Map<String, byte[]> namespaceFiles = listNamespaceFiles(runContext, fileNamespace);
+            planNamespaceFiles(runContext, baseDir, fileNamespace, gitFiles, namespaceFiles, rSourceOfTruth, rWhenMissingInSource, rProtectedNamespaces, rDryRun, diffs, apply);
+        }
 
         if (!rDryRun) {
             for (Runnable r : apply)
@@ -547,12 +578,12 @@ public class NamespaceSync extends AbstractCloningTask implements RunnableTask<N
     private record KestraState(Map<String, FlowWithSource> flows) {
     }
 
-    private KestraState loadKestraState(RunContext rc, String rootNamespace, OnInvalidSyntax rOnInvalidSyntax) {
+    private KestraState loadKestraState(RunContext rc, String rootNamespace, OnInvalidSyntax rOnInvalidSyntax, boolean includeChildNamespaces, Set<String> syncNamespaces) {
         String tenant = rc.flowInfo().tenantId();
 
         List<FlowWithSource> allFlows;
         try {
-            allFlows = fetchFlowsFromKestra(rc, tenant, rootNamespace, rOnInvalidSyntax);
+            allFlows = fetchFlowsFromKestra(rc, tenant, rootNamespace, rOnInvalidSyntax, includeChildNamespaces);
         } catch (Exception e) {
             handleInvalid(rc, rOnInvalidSyntax, "flows for namespace " + rootNamespace, e);
             allFlows = List.of();
@@ -560,16 +591,18 @@ public class NamespaceSync extends AbstractCloningTask implements RunnableTask<N
 
         Map<String, FlowWithSource> flowsWithSource = allFlows.stream()
             .filter(f -> !f.isDraft())
+            .filter(f -> syncNamespaces.contains(f.getNamespace()))
             .collect(Collectors.toMap(f -> key(f.getNamespace(), f.getId()), Function.identity(), (a, b) -> a));
 
         return new KestraState(flowsWithSource);
     }
 
-    private List<FlowWithSource> fetchFlowsFromKestra(RunContext rc, String tenantId, String namespace, OnInvalidSyntax onInvalidSyntax) {
+    private List<FlowWithSource> fetchFlowsFromKestra(RunContext rc, String tenantId, String namespace, OnInvalidSyntax onInvalidSyntax, boolean includeChildNamespaces) {
         try {
+            var op = includeChildNamespaces ? QueryFilterOp.STARTS_WITH : QueryFilterOp.EQUALS;
             byte[] zippedFlows = kestraClient(rc).flows().exportFlowsByQuery(
                 tenantId,
-                List.of(new QueryFilter().field(QueryFilterField.NAMESPACE).operation(QueryFilterOp.EQUALS).value(namespace))
+                List.of(new QueryFilter().field(QueryFilterField.NAMESPACE).operation(op).value(namespace))
             );
             List<FlowWithSource> flows = new ArrayList<>();
             try (
@@ -735,14 +768,28 @@ public class NamespaceSync extends AbstractCloningTask implements RunnableTask<N
         }
     }
 
-    private GitTree filterTreeByNamespace(GitTree src, String rootNamespace) {
+    private GitTree filterTreeByNamespace(GitTree src, Set<String> syncNamespaces) {
         GitTree out = new GitTree();
         src.nodes.forEach((k, v) ->
         {
-            if (v.namespace.equals(rootNamespace)) {
+            if (syncNamespaces.contains(v.namespace)) {
                 out.nodes.put(k, v);
             }
         });
+        return out;
+    }
+
+    private Set<String> gitDescendantNamespaces(Path baseDir, String rootNamespace) throws IOException {
+        Set<String> out = new HashSet<>();
+        if (baseDir == null || !Files.exists(baseDir))
+            return out;
+        try (Stream<Path> paths = Files.list(baseDir)) {
+            paths.filter(Files::isDirectory)
+                .filter(p -> Files.isDirectory(p.resolve(FLOWS_DIR)) || Files.isDirectory(p.resolve(FILES_DIR)))
+                .map(p -> p.getFileName().toString())
+                .filter(name -> isDescendant(rootNamespace, name))
+                .forEach(out::add);
+        }
         return out;
     }
 

--- a/src/main/java/io/kestra/plugin/git/PushNamespaceFiles.java
+++ b/src/main/java/io/kestra/plugin/git/PushNamespaceFiles.java
@@ -3,12 +3,13 @@ package io.kestra.plugin.git;
 import java.io.InputStream;
 import java.net.URI;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 import io.kestra.core.exceptions.KestraRuntimeException;
 import io.kestra.core.models.annotations.Example;
@@ -17,13 +18,13 @@ import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.storages.Namespace;
+import io.kestra.core.storages.NamespaceFile;
 import io.kestra.core.utils.PathMatcherPredicate;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 
-import static io.kestra.core.utils.Rethrow.throwFunction;
 import static io.kestra.core.utils.Rethrow.throwSupplier;
 
 @SuperBuilder(toBuilder = true)
@@ -33,7 +34,7 @@ import static io.kestra.core.utils.Rethrow.throwSupplier;
 @NoArgsConstructor
 @Schema(
     title = "Push Namespace Files to Git",
-    description = "Exports Namespace Files from a single Kestra namespace into `gitDirectory` (default `_files`) and pushes to Git. Branch is created if missing; use `files` globs to narrow the selection and `dryRun` to emit a diff only. Push sequentially to avoid merge conflicts."
+    description = "Exports Namespace Files from a Kestra namespace (optionally child namespaces) into `gitDirectory` (default `_files`) and pushes to Git. Branch is created if missing; use `files` globs to narrow the selection and `dryRun` to emit a diff only. Push sequentially to avoid merge conflicts."
 )
 @Plugin(
     examples = {
@@ -137,6 +138,14 @@ public class PushNamespaceFiles extends AbstractPushTask<PushNamespaceFiles.Outp
     private Object files;
 
     @Schema(
+        title = "Include child namespaces",
+        description = "Default false. When true, also pushes files from descendant namespaces, each under a directory named by its full dotted namespace inside `gitDirectory`."
+    )
+    @Builder.Default
+    @PluginProperty(group = "source")
+    private Property<Boolean> includeChildNamespaces = Property.ofValue(false);
+
+    @Schema(
         title = "Git commit message",
         defaultValue = "Add files from `namespace` namespace"
     )
@@ -166,18 +175,23 @@ public class PushNamespaceFiles extends AbstractPushTask<PushNamespaceFiles.Outp
     @Override
     protected Map<Path, Supplier<InputStream>> instanceResourcesContentByPath(RunContext runContext, Path baseDirectory, List<String> globs) throws Exception {
 
-        Namespace storage = runContext.storage().namespace(runContext.render(this.namespace).as(String.class).orElse(null));
+        String renderedNamespace = runContext.render(this.namespace).as(String.class).orElse(null);
         Predicate<Path> matcher = (globs != null) ? PathMatcherPredicate.matches(globs) : (path -> true);
 
-        Map<Path, Supplier<InputStream>> filesMap = storage
-            .findAllFilesMatching(matcher)
-            .stream()
-            .collect(
-                Collectors.toMap(
-                    nsFile -> baseDirectory.resolve(nsFile.path()),
-                    throwFunction(nsFile -> throwSupplier(() -> storage.getFileContent(Path.of(nsFile.path()))))
-                )
-            );
+        List<String> namespaces = new ArrayList<>();
+        namespaces.add(renderedNamespace);
+        if (runContext.render(this.includeChildNamespaces).as(Boolean.class).orElse(false)) {
+            namespaces.addAll(descendantNamespaces(runContext, runContext.flowInfo().tenantId(), renderedNamespace));
+        }
+
+        Map<Path, Supplier<InputStream>> filesMap = new HashMap<>();
+        for (String namespaceToPush : namespaces) {
+            Namespace storage = runContext.storage().namespace(namespaceToPush);
+            Path directory = namespaceToPush.equals(renderedNamespace) ? baseDirectory : baseDirectory.resolve(namespaceToPush);
+            for (NamespaceFile nsFile : storage.findAllFilesMatching(matcher)) {
+                filesMap.put(directory.resolve(nsFile.path()), throwSupplier(() -> storage.getFileContent(Path.of(nsFile.path()))));
+            }
+        }
 
         if (runContext.render(errorOnMissing).as(Boolean.class).orElse(false) && filesMap.isEmpty()) {
             throw new KestraRuntimeException("No Namespace Files matched the provided 'files' parameter to commit.");

--- a/src/main/java/io/kestra/plugin/git/SyncNamespaceFiles.java
+++ b/src/main/java/io/kestra/plugin/git/SyncNamespaceFiles.java
@@ -7,21 +7,24 @@ import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.storages.Namespace;
 import io.kestra.core.storages.NamespaceFile;
+import io.kestra.sdk.internal.ApiException;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
-import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder(toBuilder = true)
 @ToString
@@ -30,7 +33,7 @@ import io.kestra.core.models.annotations.PluginProperty;
 @NoArgsConstructor
 @Schema(
     title = "Sync Namespace Files from Git",
-    description = "Imports Namespace Files from a Git branch into a Kestra namespace. Can delete files missing in Git, honors `.kestraignore`, and supports dry-run diff output."
+    description = "Imports Namespace Files from a Git branch into a Kestra namespace (optionally child namespaces via `includeChildNamespaces`). Can delete files missing in Git, honors `.kestraignore`, and supports dry-run diff output."
 )
 @Plugin(
     examples = {
@@ -132,24 +135,49 @@ public class SyncNamespaceFiles extends AbstractSyncTask<NamespaceFile, SyncName
     @PluginProperty(group = "advanced")
     private Property<Boolean> delete = Property.ofValue(false);
 
+    @Schema(
+        title = "Include child namespaces",
+        description = "Default false. When true, a directory under `gitDirectory` named by an existing descendant namespace (full dotted name, e.g. `company.team`) is synced into that namespace, and descendant namespaces are included when `delete` is true."
+    )
+    @Builder.Default
+    @PluginProperty(group = "source")
+    private Property<Boolean> includeChildNamespaces = Property.ofValue(false);
+
+    @Getter(AccessLevel.NONE)
+    @ToString.Exclude
+    private transient List<String> resolvedChildNamespaces;
+
     @Override
     public Property<String> fetchedNamespace() {
         return this.namespace;
     }
 
+    // Fetched once per run and reused by fetchResources and resolveTarget
+    private List<String> childNamespaces(RunContext runContext, String renderedNamespace) throws IOException {
+        if (this.resolvedChildNamespaces == null) {
+            try {
+                this.resolvedChildNamespaces = descendantNamespaces(runContext, runContext.flowInfo().tenantId(), renderedNamespace);
+            } catch (ApiException | IllegalVariableEvaluationException e) {
+                throw new IOException(e);
+            }
+        }
+        return this.resolvedChildNamespaces;
+    }
+
     @Override
     protected void deleteResource(RunContext runContext, String renderedNamespace, NamespaceFile namespaceFile) throws IOException {
-        runContext.storage().namespace(renderedNamespace).delete(namespaceFile);
+        runContext.storage().namespace(namespaceFile.namespace()).delete(namespaceFile);
     }
 
     @Override
     protected NamespaceFile simulateResourceWrite(RunContext runContext, String renderedNamespace, URI uri, InputStream inputStream) throws IOException {
-        var namespace = runContext.storage().namespace(renderedNamespace);
-        var path = Path.of(uri.getPath());
-        var existingResource = this.findExistingResource(namespace, renderedNamespace, uri);
+        var target = resolveTarget(runContext, renderedNamespace, uri);
+        var namespace = runContext.storage().namespace(target.namespace());
+        var path = Path.of(target.uri().getPath());
+        var existingResource = this.findExistingResource(namespace, target.namespace(), target.uri());
 
         if (inputStream == null) {
-            return existingResource.orElseGet(() -> NamespaceFile.of(renderedNamespace, uri));
+            return existingResource.orElseGet(() -> NamespaceFile.of(target.namespace(), target.uri()));
         }
 
         if (existingResource.isPresent() && !existingResource.get().isDirectory()) {
@@ -157,17 +185,21 @@ public class SyncNamespaceFiles extends AbstractSyncTask<NamespaceFile, SyncName
                 return existingResource.get();
             }
 
-            return NamespaceFile.of(renderedNamespace, uri, existingResource.get().revision() + 1);
+            return NamespaceFile.of(target.namespace(), target.uri(), existingResource.get().revision() + 1);
         }
 
-        return NamespaceFile.of(renderedNamespace, uri);
+        return NamespaceFile.of(target.namespace(), target.uri());
     }
 
     @Override
     protected NamespaceFile writeResource(RunContext runContext, String renderedNamespace, URI uri, InputStream inputStream) throws IOException {
-        var namespace = runContext.storage().namespace(renderedNamespace);
-        var path = Path.of(uri.getPath());
-        var existingResource = this.findExistingResource(namespace, renderedNamespace, uri);
+        var target = resolveTarget(runContext, renderedNamespace, uri);
+        if (inputStream == null && "/".equals(target.uri().getPath())) {
+            return NamespaceFile.of(target.namespace());
+        }
+        var namespace = runContext.storage().namespace(target.namespace());
+        var path = Path.of(target.uri().getPath());
+        var existingResource = this.findExistingResource(namespace, target.namespace(), target.uri());
 
         try {
             if (inputStream == null) {
@@ -283,8 +315,14 @@ public class SyncNamespaceFiles extends AbstractSyncTask<NamespaceFile, SyncName
     }
 
     @Override
-    protected List<NamespaceFile> fetchResources(RunContext runContext, String renderedNamespace) throws IOException {
-        return runContext.storage().namespace(renderedNamespace).all();
+    protected List<NamespaceFile> fetchResources(RunContext runContext, String renderedNamespace) throws IOException, IllegalVariableEvaluationException {
+        List<NamespaceFile> resources = new ArrayList<>(runContext.storage().namespace(renderedNamespace).all());
+        if (runContext.render(this.includeChildNamespaces).as(Boolean.class).orElse(false)) {
+            for (String child : childNamespaces(runContext, renderedNamespace)) {
+                resources.addAll(runContext.storage().namespace(child).all());
+            }
+        }
+        return resources;
     }
 
     @Override
@@ -300,7 +338,32 @@ public class SyncNamespaceFiles extends AbstractSyncTask<NamespaceFile, SyncName
             path = path + "/";
         }
 
-        return NamespaceFile.of(renderedNamespace, path, 1).uri();
+        return NamespaceFile.of(resource.namespace(), path, 1).uri();
+    }
+
+    private record Target(String namespace, URI uri) {
+    }
+
+    // With includeChildNamespaces, a first path segment naming an existing descendant namespace routes the file there
+    private Target resolveTarget(RunContext runContext, String renderedNamespace, URI uri) throws IOException {
+        try {
+            if (!runContext.render(this.includeChildNamespaces).as(Boolean.class).orElse(false)) {
+                return new Target(renderedNamespace, uri);
+            }
+        } catch (IllegalVariableEvaluationException e) {
+            throw new IOException(e);
+        }
+
+        String raw = uri.toString().replaceFirst("^/+", "");
+        int slash = raw.indexOf('/');
+        if (slash < 0) {
+            return new Target(renderedNamespace, uri);
+        }
+        String first = raw.substring(0, slash);
+        if (!isDescendant(renderedNamespace, first) || !childNamespaces(runContext, renderedNamespace).contains(first)) {
+            return new Target(renderedNamespace, uri);
+        }
+        return new Target(first, URI.create(raw.substring(slash)));
     }
 
     @Override


### PR DESCRIPTION
Adds `includeChildNamespaces` (default `false`, non-breaking) to `NamespaceSync`, `PushNamespaceFiles` and `SyncNamespaceFiles` so a namespace and its child namespaces sync in one task. Also adds `apiToken` to the shared `AbstractCloningTask` auth so these tasks can authenticate to the Kestra API with a token (previously basic/auto only).

Companion EE PR: https://github.com/kestra-io/plugin-ee-git/pull/161