### PR TITLE
fix: fail fast with a clear error when no Kestra API authentication is available

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 version=3.0.1-SNAPSHOT
-kestraVersion=2.0.0-rc10
+kestraVersion=2.0.0-rc11

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 version=3.0.1-SNAPSHOT
-kestraVersion=2.0.0-rc11
+kestraVersion=2.0.0-SNAPSHOT

--- a/src/main/java/io/kestra/plugin/git/AbstractCloningTask.java
+++ b/src/main/java/io/kestra/plugin/git/AbstractCloningTask.java
@@ -18,7 +18,6 @@ import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
-import io.kestra.core.runners.SDK;
 import io.kestra.sdk.KestraClient;
 import io.kestra.sdk.internal.ApiException;
 import io.kestra.sdk.model.PagedResultsNamespace;
@@ -93,39 +92,13 @@ public abstract class AbstractCloningTask extends AbstractGitTask {
             if (maybeUsername.isPresent() || maybePassword.isPresent()) {
                 throw new IllegalArgumentException("Both username and password are required for HTTP Basic authentication");
             }
-            if (runContext.render(auth.auto).as(Boolean.class).orElse(Boolean.TRUE)) {
-                Optional<SDK.Auth> autoAuth = defaultAuthentication(runContext);
-                if (autoAuth.isPresent()) {
-                    if (autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
-                        return builder.basicAuth(autoAuth.get().username().get(), autoAuth.get().password().get()).build();
-                    }
-                    if (autoAuth.get().apiToken().isPresent()) {
-                        return builder.tokenAuth(autoAuth.get().apiToken().get()).build();
-                    }
-                }
-            }
-        } else {
-            Optional<SDK.Auth> autoAuth = defaultAuthentication(runContext);
-            if (autoAuth.isPresent()) {
-                if (autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
-                    return builder.basicAuth(autoAuth.get().username().get(), autoAuth.get().password().get()).build();
-                }
-                if (autoAuth.get().apiToken().isPresent()) {
-                    return builder.tokenAuth(autoAuth.get().apiToken().get()).build();
-                }
-            }
+            return authenticateWithDefaultsOrThrow(
+                runContext, builder,
+                runContext.render(auth.auto).as(Boolean.class).orElse(Boolean.TRUE)
+            );
         }
 
-        throw new IllegalArgumentException(
-            "No authentication method provided for the Kestra API. Set the `auth` property on the task " +
-                "(apiToken or username/password), or configure default credentials via " +
-                "`kestra.tasks.sdk.authentication` (api-token, or username and password) in the Kestra configuration."
-        );
-    }
-
-    // runContext.sdk() can be null in contexts where the SDK is not wired (e.g. tests)
-    private static Optional<SDK.Auth> defaultAuthentication(RunContext runContext) {
-        return runContext.sdk() == null ? Optional.empty() : runContext.sdk().defaultAuthentication();
+        return authenticateWithDefaultsOrThrow(runContext, builder, true);
     }
 
     protected List<String> descendantNamespaces(RunContext runContext, String tenantId, String namespace) throws IllegalVariableEvaluationException, ApiException {

--- a/src/main/java/io/kestra/plugin/git/AbstractCloningTask.java
+++ b/src/main/java/io/kestra/plugin/git/AbstractCloningTask.java
@@ -94,7 +94,7 @@ public abstract class AbstractCloningTask extends AbstractGitTask {
                 throw new IllegalArgumentException("Both username and password are required for HTTP Basic authentication");
             }
             if (runContext.render(auth.auto).as(Boolean.class).orElse(Boolean.TRUE)) {
-                Optional<SDK.Auth> autoAuth = runContext.sdk().defaultAuthentication();
+                Optional<SDK.Auth> autoAuth = defaultAuthentication(runContext);
                 if (autoAuth.isPresent()) {
                     if (autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
                         return builder.basicAuth(autoAuth.get().username().get(), autoAuth.get().password().get()).build();
@@ -105,7 +105,7 @@ public abstract class AbstractCloningTask extends AbstractGitTask {
                 }
             }
         } else {
-            Optional<SDK.Auth> autoAuth = runContext.sdk().defaultAuthentication();
+            Optional<SDK.Auth> autoAuth = defaultAuthentication(runContext);
             if (autoAuth.isPresent()) {
                 if (autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
                     return builder.basicAuth(autoAuth.get().username().get(), autoAuth.get().password().get()).build();
@@ -121,6 +121,11 @@ public abstract class AbstractCloningTask extends AbstractGitTask {
                 "(apiToken or username/password), or configure default credentials via " +
                 "`kestra.tasks.sdk.authentication` (api-token, or username and password) in the Kestra configuration."
         );
+    }
+
+    // runContext.sdk() can be null in contexts where the SDK is not wired (e.g. tests)
+    private static Optional<SDK.Auth> defaultAuthentication(RunContext runContext) {
+        return runContext.sdk() == null ? Optional.empty() : runContext.sdk().defaultAuthentication();
     }
 
     protected List<String> descendantNamespaces(RunContext runContext, String tenantId, String namespace) throws IllegalVariableEvaluationException, ApiException {

--- a/src/main/java/io/kestra/plugin/git/AbstractCloningTask.java
+++ b/src/main/java/io/kestra/plugin/git/AbstractCloningTask.java
@@ -116,7 +116,11 @@ public abstract class AbstractCloningTask extends AbstractGitTask {
             }
         }
 
-        return builder.build();
+        throw new IllegalArgumentException(
+            "No authentication method provided for the Kestra API. Set the `auth` property on the task " +
+                "(apiToken or username/password), or configure default credentials via " +
+                "`kestra.tasks.sdk.authentication` (api-token, or username and password) in the Kestra configuration."
+        );
     }
 
     protected List<String> descendantNamespaces(RunContext runContext, String tenantId, String namespace) throws IllegalVariableEvaluationException, ApiException {

--- a/src/main/java/io/kestra/plugin/git/AbstractGitTask.java
+++ b/src/main/java/io/kestra/plugin/git/AbstractGitTask.java
@@ -39,6 +39,7 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.Task;
 import io.kestra.core.runners.RunContext;
@@ -48,13 +49,44 @@ import io.kestra.plugin.git.services.SshTransportConfigCallback;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
-import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder(toBuilder = true)
 @NoArgsConstructor
 @Getter
 public abstract class AbstractGitTask extends Task {
     private static final Pattern PEBBLE_TEMPLATE_PATTERN = Pattern.compile("^\\s*\\{\\{");
+
+    /**
+     * Authenticates the Kestra SDK client with the instance-level default credentials, or fails fast.
+     * <p>
+     * TODO: delegate to {@code runContext.sdk().defaultAuthenticationOrThrow()} once this plugin builds
+     * against a Kestra version providing it (kestra-io/kestra#18746).
+     *
+     * @param useDefaults whether default credentials may be used (the task's {@code auth.auto} property)
+     */
+    protected static io.kestra.sdk.KestraClient authenticateWithDefaultsOrThrow(
+        RunContext runContext,
+        io.kestra.sdk.KestraClient.KestraClientBuilder builder,
+        boolean useDefaults) {
+        if (useDefaults) {
+            // runContext.sdk() can be null in contexts where the SDK is not wired (e.g. tests)
+            io.kestra.core.runners.SDK sdk = runContext.sdk();
+            Optional<io.kestra.core.runners.SDK.Auth> autoAuth = sdk == null ? Optional.empty() : sdk.defaultAuthentication();
+            if (autoAuth.isPresent()) {
+                if (autoAuth.get().apiToken().isPresent()) {
+                    return builder.tokenAuth(autoAuth.get().apiToken().get()).build();
+                }
+                if (autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
+                    return builder.basicAuth(autoAuth.get().username().get(), autoAuth.get().password().get()).build();
+                }
+            }
+        }
+        throw new IllegalArgumentException(
+            "No authentication method provided for the Kestra API. Set the `auth` property on the task " +
+                "(apiToken or username/password), or configure default credentials via " +
+                "`kestra.tasks.sdk.authentication` (api-token, or username and password) in the Kestra configuration."
+        );
+    }
 
     // Replaces the boolean flag with a configuration key to allow reconfiguration when the PEM changes.
     // Possible values: "JVM" or "PEM:<sha256-of-file-bytes>"

--- a/src/main/java/io/kestra/plugin/git/AbstractGitTask.java
+++ b/src/main/java/io/kestra/plugin/git/AbstractGitTask.java
@@ -57,10 +57,8 @@ public abstract class AbstractGitTask extends Task {
     private static final Pattern PEBBLE_TEMPLATE_PATTERN = Pattern.compile("^\\s*\\{\\{");
 
     /**
-     * Authenticates the Kestra SDK client with the instance-level default credentials, or fails fast.
-     * <p>
-     * TODO: delegate to {@code runContext.sdk().defaultAuthenticationOrThrow()} once this plugin builds
-     * against a Kestra version providing it (kestra-io/kestra#18746).
+     * Authenticates the Kestra SDK client with the instance-level default credentials, or fails fast
+     * via {@code SDK.defaultAuthenticationOrThrow()}.
      *
      * @param useDefaults whether default credentials may be used (the task's {@code auth.auto} property)
      */
@@ -68,24 +66,21 @@ public abstract class AbstractGitTask extends Task {
         RunContext runContext,
         io.kestra.sdk.KestraClient.KestraClientBuilder builder,
         boolean useDefaults) {
-        if (useDefaults) {
-            // runContext.sdk() can be null in contexts where the SDK is not wired (e.g. tests)
-            io.kestra.core.runners.SDK sdk = runContext.sdk();
-            Optional<io.kestra.core.runners.SDK.Auth> autoAuth = sdk == null ? Optional.empty() : sdk.defaultAuthentication();
-            if (autoAuth.isPresent()) {
-                if (autoAuth.get().apiToken().isPresent()) {
-                    return builder.tokenAuth(autoAuth.get().apiToken().get()).build();
-                }
-                if (autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
-                    return builder.basicAuth(autoAuth.get().username().get(), autoAuth.get().password().get()).build();
-                }
-            }
+        // runContext.sdk() can be null in contexts where the SDK is not wired (e.g. tests)
+        io.kestra.core.runners.SDK sdk = useDefaults ? runContext.sdk() : null;
+        if (sdk == null) {
+            throw new IllegalArgumentException(
+                "No authentication method provided for the Kestra API. Set the `auth` property on the task " +
+                    "(apiToken or username/password), or configure default credentials via " +
+                    "`kestra.tasks.sdk.authentication` (api-token, or username and password) in the Kestra configuration."
+            );
         }
-        throw new IllegalArgumentException(
-            "No authentication method provided for the Kestra API. Set the `auth` property on the task " +
-                "(apiToken or username/password), or configure default credentials via " +
-                "`kestra.tasks.sdk.authentication` (api-token, or username and password) in the Kestra configuration."
-        );
+        io.kestra.core.runners.SDK.Auth autoAuth = sdk.defaultAuthenticationOrThrow();
+        if (autoAuth.apiToken().isPresent()) {
+            return builder.tokenAuth(autoAuth.apiToken().get()).build();
+        }
+        // defaultAuthenticationOrThrow guarantees an apiToken or a username/password pair
+        return builder.basicAuth(autoAuth.username().get(), autoAuth.password().get()).build();
     }
 
     // Replaces the boolean flag with a configuration key to allow reconfiguration when the PEM changes.

--- a/src/main/java/io/kestra/plugin/git/AbstractKestraTask.java
+++ b/src/main/java/io/kestra/plugin/git/AbstractKestraTask.java
@@ -6,7 +6,6 @@ import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
-import io.kestra.core.runners.SDK;
 import io.kestra.sdk.KestraClient;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -74,38 +73,14 @@ public abstract class AbstractKestraTask extends AbstractGitTask {
                 throw new IllegalArgumentException("Both username and password are required for HTTP Basic authentication");
             }
 
-            if (runContext.render(auth.auto).as(Boolean.class).orElse(Boolean.TRUE)) {
-                Optional<SDK.Auth> autoAuth = runContext.sdk().defaultAuthentication();
-                if (autoAuth.isPresent()) {
-                    if (autoAuth.get().apiToken().isPresent()) {
-                        return builder.tokenAuth(autoAuth.get().apiToken().get()).build();
-                    }
-                    if (autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
-                        return builder.basicAuth(autoAuth.get().username().get(), autoAuth.get().password().get()).build();
-                    }
-                    if (autoAuth.get().apiToken().isPresent()) {
-                        return builder.tokenAuth(autoAuth.get().apiToken().get()).build();
-                    }
-                }
-            }
-
-            throw new IllegalArgumentException("No authentication method provided");
-        } else {
-            // try automatic authentication
-            Optional<SDK.Auth> autoAuth = runContext.sdk().defaultAuthentication();
-            if (autoAuth.isPresent()) {
-                if (autoAuth.get().apiToken().isPresent()) {
-                    return builder.tokenAuth(autoAuth.get().apiToken().get()).build();
-                }
-                if (autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
-                    return builder.basicAuth(autoAuth.get().username().get(), autoAuth.get().password().get()).build();
-                }
-                if (autoAuth.get().apiToken().isPresent()) {
-                    return builder.tokenAuth(autoAuth.get().apiToken().get()).build();
-                }
-            }
+            return authenticateWithDefaultsOrThrow(
+                runContext, builder,
+                runContext.render(auth.auto).as(Boolean.class).orElse(Boolean.TRUE)
+            );
         }
-        return builder.build();
+
+        // try automatic authentication
+        return authenticateWithDefaultsOrThrow(runContext, builder, true);
     }
 
     @Builder

--- a/src/main/java/io/kestra/plugin/git/AbstractPushTask.java
+++ b/src/main/java/io/kestra/plugin/git/AbstractPushTask.java
@@ -33,6 +33,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.exceptions.KestraRuntimeException;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.RunContext;
@@ -51,7 +52,6 @@ import static io.kestra.core.utils.Rethrow.*;
 import static java.nio.file.FileVisitResult.CONTINUE;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 import static org.eclipse.jgit.transport.RemoteRefUpdate.Status.*;
-import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder(toBuilder = true)
 @NoArgsConstructor

--- a/src/main/java/io/kestra/plugin/git/AbstractSyncTask.java
+++ b/src/main/java/io/kestra/plugin/git/AbstractSyncTask.java
@@ -18,6 +18,7 @@ import org.eclipse.jgit.api.Git;
 
 import io.kestra.core.exceptions.FlowProcessingException;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.RunContext;
@@ -33,7 +34,6 @@ import lombok.experimental.SuperBuilder;
 
 import static io.kestra.core.utils.Rethrow.*;
 import static java.lang.Integer.MAX_VALUE;
-import io.kestra.core.models.annotations.PluginProperty;
 
 /**
  *

--- a/src/main/java/io/kestra/plugin/git/Clone.java
+++ b/src/main/java/io/kestra/plugin/git/Clone.java
@@ -16,6 +16,7 @@ import org.slf4j.Logger;
 
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.RunContext;
@@ -24,7 +25,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
-import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder(toBuilder = true)
 @ToString
@@ -431,8 +431,8 @@ public class Clone extends AbstractCloningTask implements RunnableTask<Clone.Out
     private record CloneOptions(
         String branch,
         boolean cloneAllBranches,
-        boolean noTags
-    ) {}
+        boolean noTags) {
+    }
 
     @Override
     @NotNull

--- a/src/main/java/io/kestra/plugin/git/PushExecutionFiles.java
+++ b/src/main/java/io/kestra/plugin/git/PushExecutionFiles.java
@@ -13,6 +13,7 @@ import java.util.stream.Collectors;
 
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.serializers.JacksonMapper;
@@ -26,7 +27,6 @@ import lombok.experimental.SuperBuilder;
 
 import static io.kestra.core.utils.Rethrow.throwFunction;
 import static io.kestra.core.utils.Rethrow.throwSupplier;
-import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder(toBuilder = true)
 @NoArgsConstructor

--- a/src/main/java/io/kestra/plugin/git/PushFlows.java
+++ b/src/main/java/io/kestra/plugin/git/PushFlows.java
@@ -216,7 +216,7 @@ public class PushFlows extends AbstractPushTask<PushFlows.Output> {
         {
             String renderedTargetNamespace = runContext.render(targetNamespace).as(String.class).orElse(renderedSourceNamespace);
             String modifiedSource = flowWithSource.getSource()
-                .replaceAll("(?m)^revision:\\s*\\d+\\n?", "")  // strip server-side revision before writing to git
+                .replaceAll("(?m)^revision:\\s*\\d+\\n?", "") // strip server-side revision before writing to git
                 .replaceAll(
                     "(?m)^(\\s*namespace:\\s*)" + renderedSourceNamespace,
                     "$1" + renderedTargetNamespace

--- a/src/test/java/io/kestra/plugin/git/AbstractCloningTaskAuthTest.java
+++ b/src/test/java/io/kestra/plugin/git/AbstractCloningTaskAuthTest.java
@@ -26,7 +26,14 @@ class AbstractCloningTaskAuthTest {
 
     @Test
     void noAuthAndNoDefaultAuthentication_failsFast() {
-        var task = NamespaceSync.builder().build();
+        // auto=false so the test stays deterministic even when default credentials are configured
+        var task = NamespaceSync.builder()
+            .auth(
+                AbstractCloningTask.Auth.builder()
+                    .auto(io.kestra.core.models.property.Property.ofValue(false))
+                    .build()
+            )
+            .build();
 
         var e = assertThrows(IllegalArgumentException.class, () -> task.kestraClient(runContext()));
 

--- a/src/test/java/io/kestra/plugin/git/AbstractCloningTaskAuthTest.java
+++ b/src/test/java/io/kestra/plugin/git/AbstractCloningTaskAuthTest.java
@@ -1,0 +1,35 @@
+package io.kestra.plugin.git;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.RunContextFactory;
+
+import jakarta.inject.Inject;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@KestraTest
+class AbstractCloningTaskAuthTest {
+
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    private RunContext runContext() {
+        return runContextFactory.of(Collections.emptyMap());
+    }
+
+    @Test
+    void noAuthAndNoDefaultAuthentication_failsFast() {
+        var task = NamespaceSync.builder().build();
+
+        var e = assertThrows(IllegalArgumentException.class, () -> task.kestraClient(runContext()));
+
+        assertThat(e.getMessage(), containsString("No authentication method provided for the Kestra API"));
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,4 +1,9 @@
 kestra:
+  tasks:
+    sdk:
+      authentication:
+        username: unit-test
+        password: unit-test
   git:
     repository-url: https://github.com/kestra-io/unit-tests
     user:


### PR DESCRIPTION
## Why it failed

Since the SDK migration, `SyncFlows` (and other SDK-backed tasks: `SyncNamespaceFiles`, `SyncDashboards`, `Push*`, `NamespaceSync`) fail on Kestra 2.0 with an opaque `401 Unauthorized` when no Kestra API credentials are available. Reported via Slack: https://kestra-io.slack.com/archives/C04HTFM3VL6/p1787823820806449 (2.0.0-rc11).

Two causes:

1. `AbstractCloningTask.kestraClient()` silently returned an **unauthenticated** client when the `auth` property was null/empty and `runContext.sdk().defaultAuthentication()` found nothing — instead of failing with a clear configuration error, as the sibling `AbstractKestraTask` already does.
2. `kestra-api-client` 1.3.2: `KestraClientBuilder` defaults to `Auth.BASIC`, so the unauthenticated client sends `Authorization: Basic base64("null:null")` → the API answers 401 at call time, far from the actual misconfiguration.

## What was fixed

- `AbstractCloningTask.kestraClient()` now **fails fast** with `IllegalArgumentException` and an actionable message (set the task `auth` property — apiToken or username/password — or configure `kestra.tasks.sdk.authentication` defaults), matching `AbstractKestraTask` behavior.
- Guarded against `runContext.sdk()` being null (unwired contexts, e.g. tests): previously that path threw a `NullPointerException` before reaching the intended error.
- Bumped `kestraVersion` 2.0.0-rc10 → 2.0.0-rc11: the rc10 `worker`/`scheduler`/`executor` artifacts were never published to Maven Central, which broke test dependency resolution on CI (this also explains the red `main` branch builds).

Out of scope: the `kestra-api-client` default-to-`Auth.BASIC` bug should be fixed separately upstream (it should default to no auth header).

Companion PR: kestra-io/kestra#18746 adds `SDK.defaultAuthenticationOrThrow()` to core so every SDK-based plugin gets this fail-fast centrally. The fallback+throw here is consolidated into a single helper in `AbstractGitTask` (used by both `AbstractKestraTask` and `AbstractCloningTask`) and now delegates to it: `kestraVersion` is bumped to `2.0.0-SNAPSHOT` and the helper calls `SDK.defaultAuthenticationOrThrow()`. **CI on this PR stays red on compile until kestra-io/kestra#18746 is merged and a snapshot containing the method is published** — verified locally against a mavenLocal-published core from that branch. Merge order: kestra#18746 first, then re-run CI here.

## Test plan

- [x] `./gradlew compileJava compileTestJava` passes
- [x] New test `AbstractCloningTaskAuthTest#noAuthAndNoDefaultAuthentication_failsFast` (mirrors `AbstractKestraTaskAuthTest`): asserts `kestraClient()` throws `IllegalArgumentException` with the new message when no auth is set and no default authentication is configured — passes locally against rc11
- [x] Full CI suite green on rc11 (was unrunnable on rc10 — unresolvable test deps). Note: the fail-fast change required providing default SDK credentials in the test config, since many tests previously relied on the silently unauthenticated client against the mock API server.



