### PR TITLE
feat(git): resolve the Kestra API URL from the default SDK authentication

### DIFF
--- a/src/main/java/io/kestra/plugin/git/AbstractCloningTask.java
+++ b/src/main/java/io/kestra/plugin/git/AbstractCloningTask.java
@@ -32,15 +32,13 @@ import lombok.extern.jackson.Jacksonized;
 @NoArgsConstructor
 @Getter
 public abstract class AbstractCloningTask extends AbstractGitTask {
-    private static final String DEFAULT_KESTRA_URL = "http://localhost:8080";
-    private static final String KESTRA_URL_TEMPLATE = "{{ kestra.url }}";
-
     @Schema(
         title = "Kestra API URL",
         description = """
             URL of the Kestra server API.
-            If not set, the value of `kestra.url` from the Kestra configuration is used.
-            If that is also not set, defaults to `http://localhost:8080`."""
+            If not set, the URL of the default SDK authentication is used, set with the `kestra.tasks.sdk.authentication.url` \
+            configuration property, or at the namespace or the tenant level on the Enterprise Edition.
+            It then falls back to the `kestra.url` configuration property, and finally to `http://localhost:8080`."""
     )
     @PluginProperty(group = "connection")
     protected Property<String> kestraUrl;
@@ -57,25 +55,11 @@ public abstract class AbstractCloningTask extends AbstractGitTask {
     protected Auth auth;
 
     protected KestraClient kestraClient(RunContext runContext) throws IllegalVariableEvaluationException {
-        String rKestraUrl = runContext.render(kestraUrl).as(String.class)
-            .orElseGet(() ->
-            {
-                try {
-                    String rendered = runContext.render(KESTRA_URL_TEMPLATE);
-                    return (rendered == null || rendered.isBlank()) ? DEFAULT_KESTRA_URL : rendered;
-                } catch (IllegalVariableEvaluationException e) {
-                    return DEFAULT_KESTRA_URL;
-                }
-            });
+        KestraApiConnection connection = KestraApiConnection.resolve(runContext, kestraUrl, auth);
 
-        if (rKestraUrl == null || rKestraUrl.isBlank()) {
-            rKestraUrl = DEFAULT_KESTRA_URL;
-        }
+        runContext.logger().debug("Kestra URL: {}", connection.url());
 
-        runContext.logger().debug("Kestra URL: {}", rKestraUrl);
-
-        var normalizedUrl = rKestraUrl.trim().replaceAll("/+$", "");
-        var builder = KestraClient.builder().url(normalizedUrl);
+        var builder = KestraClient.builder().url(connection.url());
 
         if (auth != null) {
             Optional<String> maybeApiToken = runContext.render(auth.apiToken).as(String.class);
@@ -93,26 +77,15 @@ public abstract class AbstractCloningTask extends AbstractGitTask {
             if (maybeUsername.isPresent() || maybePassword.isPresent()) {
                 throw new IllegalArgumentException("Both username and password are required for HTTP Basic authentication");
             }
-            if (runContext.render(auth.auto).as(Boolean.class).orElse(Boolean.TRUE)) {
-                Optional<SDK.Auth> autoAuth = runContext.sdk().defaultAuthentication();
-                if (autoAuth.isPresent()) {
-                    if (autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
-                        return builder.basicAuth(autoAuth.get().username().get(), autoAuth.get().password().get()).build();
-                    }
-                    if (autoAuth.get().apiToken().isPresent()) {
-                        return builder.tokenAuth(autoAuth.get().apiToken().get()).build();
-                    }
-                }
+        }
+
+        Optional<SDK.Auth> autoAuth = connection.defaultAuth();
+        if (autoAuth.isPresent()) {
+            if (autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
+                return builder.basicAuth(autoAuth.get().username().get(), autoAuth.get().password().get()).build();
             }
-        } else {
-            Optional<SDK.Auth> autoAuth = runContext.sdk().defaultAuthentication();
-            if (autoAuth.isPresent()) {
-                if (autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
-                    return builder.basicAuth(autoAuth.get().username().get(), autoAuth.get().password().get()).build();
-                }
-                if (autoAuth.get().apiToken().isPresent()) {
-                    return builder.tokenAuth(autoAuth.get().apiToken().get()).build();
-                }
+            if (autoAuth.get().apiToken().isPresent()) {
+                return builder.tokenAuth(autoAuth.get().apiToken().get()).build();
             }
         }
 
@@ -150,7 +123,7 @@ public abstract class AbstractCloningTask extends AbstractGitTask {
     @Builder
     @Getter
     @Jacksonized
-    public static class Auth {
+    public static class Auth implements KestraApiAuth {
         @Schema(title = "Username for HTTP Basic authentication.")
         @PluginProperty(secret = true, group = "connection")
         private Property<String> username;
@@ -164,11 +137,13 @@ public abstract class AbstractCloningTask extends AbstractGitTask {
         private Property<String> apiToken;
 
         @Schema(
-            title = "Automatically retrieve credentials from Kestra's configuration if available",
+            title = "Automatically retrieve the URL and the credentials from Kestra's configuration if available",
             description = """
                 Can be configured globally in the Kestra configuration file:
+                - Set `kestra.tasks.sdk.authentication.url` for the API URL
                 - Set `kestra.tasks.sdk.authentication.api-token` for API token auth
-                - Set `kestra.tasks.sdk.authentication.username` and `kestra.tasks.sdk.authentication.password` for HTTP Basic auth"""
+                - Set `kestra.tasks.sdk.authentication.username` and `kestra.tasks.sdk.authentication.password` for HTTP Basic auth
+                The Enterprise Edition also allows an administrator to set these defaults at the namespace or the tenant level."""
         )
         @Builder.Default
         @PluginProperty(group = "advanced")

--- a/src/main/java/io/kestra/plugin/git/AbstractKestraTask.java
+++ b/src/main/java/io/kestra/plugin/git/AbstractKestraTask.java
@@ -21,14 +21,16 @@ import lombok.extern.jackson.Jacksonized;
 @EqualsAndHashCode
 @Getter
 public abstract class AbstractKestraTask extends AbstractGitTask {
-    private static final String DEFAULT_KESTRA_URL = "http://localhost:8080";
-    private static final String KESTRA_URL_TEMPLATE = "{{ kestra.url }}";
-
     @Schema(
-        title = "Kestra API URL. If null, uses 'kestra.url' from [configuration](https://kestra.io/docs/configuration#kestra-url). If that is also null, defaults to 'http://localhost:8080'"
+        title = "Kestra API URL",
+        description = """
+            URL of the Kestra server API.
+            If not set, the URL of the default SDK authentication is used, set with the `kestra.tasks.sdk.authentication.url` \
+            configuration property, or at the namespace or the tenant level on the Enterprise Edition.
+            It then falls back to the `kestra.url` configuration property, and finally to `http://localhost:8080`."""
     )
     @PluginProperty(group = "connection")
-    private Property<String> kestraUrl;
+    protected Property<String> kestraUrl;
 
     @Schema(title = "Authentication information")
     @NotNull
@@ -36,23 +38,12 @@ public abstract class AbstractKestraTask extends AbstractGitTask {
     private Auth auth;
 
     protected KestraClient kestraClient(RunContext runContext) throws IllegalVariableEvaluationException {
-        // use the kestraUrl property if set, otherwise the config value, or else the default
-        String rKestraUrl = runContext.render(kestraUrl).as(String.class)
-            .orElseGet(() ->
-            {
-                try {
-                    return runContext.render(KESTRA_URL_TEMPLATE);
-                } catch (IllegalVariableEvaluationException e) {
-                    return DEFAULT_KESTRA_URL;
-                }
-            });
+        KestraApiConnection connection = KestraApiConnection.resolve(runContext, kestraUrl, auth);
 
-        runContext.logger().debug("Kestra URL: {}", rKestraUrl);
-
-        String normalizedUrl = rKestraUrl.trim().replaceAll("/+$", "");
+        runContext.logger().debug("Kestra URL: {}", connection.url());
 
         var builder = KestraClient.builder();
-        builder.url(normalizedUrl);
+        builder.url(connection.url());
         if (auth != null) {
             if (auth.apiToken != null && (auth.username != null || auth.password != null)) {
                 throw new IllegalArgumentException("Cannot use both API Token authentication and HTTP Basic authentication");
@@ -74,44 +65,41 @@ public abstract class AbstractKestraTask extends AbstractGitTask {
                 throw new IllegalArgumentException("Both username and password are required for HTTP Basic authentication");
             }
 
-            if (runContext.render(auth.auto).as(Boolean.class).orElse(Boolean.TRUE)) {
-                Optional<SDK.Auth> autoAuth = runContext.sdk().defaultAuthentication();
-                if (autoAuth.isPresent()) {
-                    if (autoAuth.get().apiToken().isPresent()) {
-                        return builder.tokenAuth(autoAuth.get().apiToken().get()).build();
-                    }
-                    if (autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
-                        return builder.basicAuth(autoAuth.get().username().get(), autoAuth.get().password().get()).build();
-                    }
-                    if (autoAuth.get().apiToken().isPresent()) {
-                        return builder.tokenAuth(autoAuth.get().apiToken().get()).build();
-                    }
-                }
+            Optional<KestraClient> autoAuthenticated = applyDefaultCredentials(builder, connection.defaultAuth());
+            if (autoAuthenticated.isPresent()) {
+                return autoAuthenticated.get();
             }
 
-            throw new IllegalArgumentException("No authentication method provided");
+            throw new IllegalArgumentException(
+                "No authentication method provided. Set 'auth.apiToken', or 'auth.username' and 'auth.password', or configure a default one with the 'kestra.tasks.sdk.authentication' properties."
+            );
         } else {
             // try automatic authentication
-            Optional<SDK.Auth> autoAuth = runContext.sdk().defaultAuthentication();
-            if (autoAuth.isPresent()) {
-                if (autoAuth.get().apiToken().isPresent()) {
-                    return builder.tokenAuth(autoAuth.get().apiToken().get()).build();
-                }
-                if (autoAuth.get().username().isPresent() && autoAuth.get().password().isPresent()) {
-                    return builder.basicAuth(autoAuth.get().username().get(), autoAuth.get().password().get()).build();
-                }
-                if (autoAuth.get().apiToken().isPresent()) {
-                    return builder.tokenAuth(autoAuth.get().apiToken().get()).build();
-                }
+            Optional<KestraClient> autoAuthenticated = applyDefaultCredentials(builder, connection.defaultAuth());
+            if (autoAuthenticated.isPresent()) {
+                return autoAuthenticated.get();
             }
         }
         return builder.build();
     }
 
+    private static Optional<KestraClient> applyDefaultCredentials(KestraClient.KestraClientBuilder builder, Optional<SDK.Auth> defaultAuth) {
+        return defaultAuth.map(defaults ->
+        {
+            if (defaults.apiToken().isPresent()) {
+                return builder.tokenAuth(defaults.apiToken().get()).build();
+            }
+            if (defaults.username().isPresent() && defaults.password().isPresent()) {
+                return builder.basicAuth(defaults.username().get(), defaults.password().get()).build();
+            }
+            return null;
+        });
+    }
+
     @Builder
     @Getter
     @Jacksonized
-    public static class Auth {
+    public static class Auth implements KestraApiAuth {
         @Schema(title = "API token for Bearer authentication")
         @PluginProperty(secret = true, group = "connection")
         private Property<String> apiToken;
@@ -125,9 +113,10 @@ public abstract class AbstractKestraTask extends AbstractGitTask {
         private Property<String> password;
 
         @Schema(
-            title = "Automatically retrieve credentials from Kestra's configuration if available",
+            title = "Automatically retrieve the URL and the credentials from Kestra's configuration if available",
             description = """
                 The default configuration can be configured globally inside the Kestra configuration file:
+                - Set `kestra.tasks.sdk.authentication.url` to use a given API URL
                 - Set `kestra.tasks.sdk.authentication.api-token` to use an API token
                 - Set `kestra.tasks.sdk.authentication.username` and `kestra.tasks.sdk.authentication.password` for HTTP basic authentication
                 The Enterprise edition also provides setting a default configuration at the Namespace of Tenant level by an administrator."""

--- a/src/main/java/io/kestra/plugin/git/KestraApiAuth.java
+++ b/src/main/java/io/kestra/plugin/git/KestraApiAuth.java
@@ -1,0 +1,12 @@
+package io.kestra.plugin.git;
+
+import io.kestra.core.models.property.Property;
+
+/**
+ * The Kestra API connection settings a task exposes under its {@code auth} property.
+ *
+ * <p>Implemented by the {@code Auth} class of each task hierarchy so that the URL resolution is written once.
+ */
+interface KestraApiAuth {
+    Property<Boolean> getAuto();
+}

--- a/src/main/java/io/kestra/plugin/git/KestraApiConnection.java
+++ b/src/main/java/io/kestra/plugin/git/KestraApiConnection.java
@@ -1,0 +1,91 @@
+package io.kestra.plugin.git;
+
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.SDK;
+
+import jakarta.annotation.Nullable;
+
+/**
+ * The Kestra API endpoint a task talks to, together with the default SDK authentication it was resolved from.
+ *
+ * <p>
+ * Both are read from the same place, so that an instance, tenant or namespace default covers the URL as well as
+ * the credentials.
+ */
+final class KestraApiConnection {
+    private static final String DEFAULT_URL = "http://localhost:8080";
+    private static final String URL_TEMPLATE = "{{ kestra.url }}";
+
+    private final String url;
+    private final DefaultAuthSupplier defaultAuth;
+
+    private KestraApiConnection(String url, DefaultAuthSupplier defaultAuth) {
+        this.url = url;
+        this.defaultAuth = defaultAuth;
+    }
+
+    /** The API URL, without any trailing slash. */
+    String url() {
+        return url;
+    }
+
+    /** The default SDK authentication, empty when the task opted out of it with {@code auth.auto}. */
+    Optional<SDK.Auth> defaultAuth() {
+        return defaultAuth.get();
+    }
+
+    /**
+     * Resolves the API URL from, in order: the task's own {@code kestraUrl}, the default SDK authentication
+     * (namespace then tenant then instance configuration, on the Enterprise Edition), the {@code kestra.url}
+     * configuration property, and finally {@code http://localhost:8080}.
+     *
+     * <p>{@code auth.auto} opts out of the default authentication for the URL as well as for the credentials.
+     */
+    static KestraApiConnection resolve(RunContext runContext, @Nullable Property<String> kestraUrl, @Nullable KestraApiAuth auth) throws IllegalVariableEvaluationException {
+        boolean rAuto = runContext.render(Optional.ofNullable(auth).map(KestraApiAuth::getAuto).orElse(null))
+            .as(Boolean.class)
+            .orElse(Boolean.TRUE);
+        DefaultAuthSupplier defaultAuth = new DefaultAuthSupplier(runContext, rAuto);
+
+        String rUrl = runContext.render(kestraUrl).as(String.class)
+            .filter(Predicate.not(String::isBlank))
+            .or(() -> defaultAuth.get().flatMap(SDK.Auth::url).filter(Predicate.not(String::isBlank)))
+            .orElseGet(() -> configuredUrl(runContext));
+
+        return new KestraApiConnection(rUrl.trim().replaceAll("/+$", ""), defaultAuth);
+    }
+
+    private static String configuredUrl(RunContext runContext) {
+        try {
+            String rUrl = runContext.render(URL_TEMPLATE);
+            return rUrl == null || rUrl.isBlank() ? DEFAULT_URL : rUrl;
+        } catch (IllegalVariableEvaluationException e) {
+            return DEFAULT_URL;
+        }
+    }
+
+    /** Looks the defaults up at most once, since on the Enterprise Edition it reads the namespace and tenant metastores. */
+    private static final class DefaultAuthSupplier {
+        private final RunContext runContext;
+        private final boolean enabled;
+        private Optional<SDK.Auth> resolved;
+
+        private DefaultAuthSupplier(RunContext runContext, boolean enabled) {
+            this.runContext = runContext;
+            this.enabled = enabled;
+        }
+
+        private Optional<SDK.Auth> get() {
+            if (resolved == null) {
+                SDK sdk = enabled ? runContext.sdk() : null;
+                resolved = Optional.ofNullable(sdk).map(SDK::defaultAuthentication).orElse(Optional.empty());
+            }
+            return resolved;
+        }
+    }
+}

--- a/src/main/resources/doc/io.kestra.plugin.git.md
+++ b/src/main/resources/doc/io.kestra.plugin.git.md
@@ -6,6 +6,8 @@ Most Git tasks run inside a `WorkingDirectory` task so that cloned files are ava
 
 For HTTPS authentication, set `username` and `password` — use a personal access token as the `password` value for GitHub, GitLab, and Bitbucket rather than your account password. For SSH, set `privateKey` to the PEM-encoded key content (not a file path) and `passphrase` if the key is protected. Store both in [secrets](https://kestra.io/docs/concepts/secret).
 
+Tasks that call the Kestra API take `kestraUrl` for the API endpoint and an `auth` block with either `apiToken` or `username` + `password`. All of them default to the authentication configured with the `kestra.tasks.sdk.authentication` properties, or at the namespace or tenant level; `kestraUrl` then falls back to the `kestra.url` configuration property and finally to `http://localhost:8080`. Set `auth.auto: false` to opt out of the defaults, for the URL as well as for the credentials.
+
 ## Tasks
 
 The plugin covers two directions. To run code from a repository, use `Clone` inside a `WorkingDirectory` — cloned files are then available to all subsequent tasks in that working directory. `depth: 1` (the default) gives a shallow clone; set `commit` to check out a specific SHA or `tag` to check out a tag, both of which disable shallow cloning. To keep Kestra in sync with a Git repository, use `SyncFlows` to pull flow definitions and `SyncNamespaceFiles` to pull namespace files from a branch into a target namespace; set `delete: true` on either to remove resources that no longer exist in Git. To push Kestra configuration back to version control, use `PushFlows` for flows and `PushNamespaceFiles` for namespace files.

--- a/src/test/java/io/kestra/plugin/git/KestraApiConnectionTest.java
+++ b/src/test/java/io/kestra/plugin/git/KestraApiConnectionTest.java
@@ -1,0 +1,122 @@
+package io.kestra.plugin.git;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.models.tasks.Task;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.runners.SDK;
+import io.kestra.core.utils.TestsUtils;
+import io.kestra.sdk.KestraClient;
+
+import jakarta.inject.Inject;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/** The API URL comes from the same default SDK authentication as the credentials, so one instance-wide setting covers both. */
+@KestraTest
+class KestraApiConnectionTest {
+    private static final String DEFAULT_URL = "http://localhost:8080";
+    private static final String SDK_DEFAULT_URL = "https://sdk-default.example.com";
+
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    /**
+     * The default authentication normally comes from the application configuration, but declaring it with
+     * {@code @Property} would spawn a second Micronaut context, and the two embedded servers then fight over the same
+     * port. Swapping the SDK on the run context keeps the whole suite on a single context.
+     */
+    private RunContext runContextWithSdkUrl(Task task, String url) throws Exception {
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
+
+        SDK sdk = () -> Optional.of(new SDK.Auth(Optional.of(url), Optional.empty(), Optional.empty(), Optional.empty()));
+        Field sdkField = runContext.getClass().getDeclaredField("sdk");
+        sdkField.setAccessible(true);
+        sdkField.set(runContext, sdk);
+
+        return runContext;
+    }
+
+    /** Reads the URL the client was built with (the SDK only exposes it on its inner API client). */
+    private static String url(KestraClient client) throws Exception {
+        Field apiClientField = KestraClient.class.getDeclaredField("apiClient");
+        apiClientField.setAccessible(true);
+        Object apiClient = apiClientField.get(client);
+
+        return (String) apiClient.getClass().getMethod("getBasePath").invoke(apiClient);
+    }
+
+    private static Clone.CloneBuilder<?, ?> cloneTask() {
+        return Clone.builder()
+            .id("clone")
+            .type(Clone.class.getName())
+            .url(Property.ofValue("https://github.com/kestra-io/plugin-git"));
+    }
+
+    @Test
+    void shouldUseTheDefaultSdkAuthenticationUrlWhenTheTaskDoesNotSetOne() throws Exception {
+        var task = cloneTask().build();
+
+        assertThat(url(task.kestraClient(runContextWithSdkUrl(task, SDK_DEFAULT_URL))), is(SDK_DEFAULT_URL));
+    }
+
+    @Test
+    void shouldUseTheDefaultSdkAuthenticationUrlForKestraApiTasks() throws Exception {
+        var task = TenantSync.builder()
+            .id("tenantSync")
+            .type(TenantSync.class.getName())
+            .url(Property.ofValue("https://github.com/kestra-io/plugin-git"))
+            .branch(Property.ofValue("main"))
+            .auth(AbstractKestraTask.Auth.builder().apiToken(Property.ofValue("token")).build())
+            .build();
+
+        assertThat(url(task.kestraClient(runContextWithSdkUrl(task, SDK_DEFAULT_URL))), is(SDK_DEFAULT_URL));
+    }
+
+    @Test
+    void shouldPreferTheTaskUrlOverTheDefaultSdkAuthenticationUrl() throws Exception {
+        var task = cloneTask().kestraUrl(Property.ofValue("https://task.example.com/")).build();
+
+        assertThat(url(task.kestraClient(runContextWithSdkUrl(task, SDK_DEFAULT_URL))), is("https://task.example.com"));
+    }
+
+    @Test
+    void shouldFallThroughWhenTheDefaultSdkAuthenticationUrlIsBlank() throws Exception {
+        var task = cloneTask().build();
+
+        assertThat(url(task.kestraClient(runContextWithSdkUrl(task, "   "))), is(DEFAULT_URL));
+    }
+
+    @Test
+    void shouldIgnoreTheDefaultSdkAuthenticationUrlWhenAutoIsDisabled() throws Exception {
+        var task = cloneTask()
+            .auth(AbstractCloningTask.Auth.builder().auto(Property.ofValue(false)).build())
+            .build();
+
+        assertThat(url(task.kestraClient(runContextWithSdkUrl(task, SDK_DEFAULT_URL))), is(DEFAULT_URL));
+    }
+    /** The SDK builder defaults to Basic auth, so building a client without credentials would send `Basic base64("null:null")`. */
+    @Test
+    void shouldFailWhenAutoIsDisabledWithoutCredentials() throws Exception {
+        var task = TenantSync.builder()
+            .id("tenantSync")
+            .type(TenantSync.class.getName())
+            .url(Property.ofValue("https://github.com/kestra-io/plugin-git"))
+            .branch(Property.ofValue("main"))
+            .auth(AbstractKestraTask.Auth.builder().auto(Property.ofValue(false)).build())
+            .build();
+
+        RunContext runContext = runContextWithSdkUrl(task, SDK_DEFAULT_URL);
+
+        assertThrows(IllegalArgumentException.class, () -> task.kestraClient(runContext));
+    }
+}


### PR DESCRIPTION
Closes https://github.com/kestra-io/plugin-git/issues/328.

- `kestraUrl` was resolved on its own and ignored the default SDK authentication, which already carries a URL next to the credentials — so an instance, tenant or namespace default only ever applied to the credentials, never to the URL, and every task had to repeat the URL by hand.
- It now falls back exactly like `apiToken` and `username`/`password`: default SDK authentication, then `kestra.url`, then `http://localhost:8080`. `auth.auto: false` opts out of the default URL as well as of the default credentials.
- Both task hierarchies (`AbstractCloningTask`, `AbstractKestraTask`) had their own copy of the resolution; it now lives in `KestraApiConnection`, which looks the defaults up **once per client** instead of once per call site, and tolerates an SDK that returns no authentication rather than leaking a null through the chain.
- Also fixes a latent bug in the old code: the result of rendering `{{ kestra.url }}` was used without a blank check.
- Requires Kestra `2.0.0-rc12` or later, the first release exposing `SDK.Auth.url` (kestra-io/kestra#18605). `main` is already on `rc13`, so this PR no longer changes `kestraVersion`.

This deliberately matches `plugin-kestra`, which resolves the same chain in `AbstractKestraTask`/`AbstractKestraTrigger` (commit `80fc94b`): `kestraUrl` stays a top-level property, and `auth.auto` is the only opt-out. **Not a breaking change** — no property is renamed or removed.

Companion PR: https://github.com/kestra-io/plugin-ee-git/pull/164 — same change, same branch name.

A review follow-up briefly let `auth.auto: false` with no credentials build an unauthenticated client; it throws again, because that client is not actually unauthenticated — the SDK's `KestraClientBuilder` starts on `Auth.BASIC` and exposes no setter for `Auth.NONE`, so `build()` without credentials sends `Authorization: Basic base64("null:null")`. Calling an API that accepts anonymous calls needs a `noAuth()` on that builder in `client-sdk` first.


