### PR TITLE
fix(flows): avoid NPE in SyncFlows on repeated syncs

### DIFF
--- a/src/main/java/io/kestra/plugin/git/SyncFlows.java
+++ b/src/main/java/io/kestra/plugin/git/SyncFlows.java
@@ -119,6 +119,7 @@ import lombok.experimental.SuperBuilder;
 )
 public class SyncFlows extends AbstractSyncTask<Flow, SyncFlows.Output> {
     public static final Pattern NAMESPACE_FINDER_PATTERN = Pattern.compile("(?m)^namespace: (.*)$");
+    private static final Pattern REVISION_LINE_PATTERN = Pattern.compile("(?m)^revision:\\s*\\d+\\n?");
 
     @Schema(
         title = "Branch to sync",
@@ -208,7 +209,7 @@ public class SyncFlows extends AbstractSyncTask<Flow, SyncFlows.Output> {
         // Simulate: parse the source and determine if it differs from the current Kestra state
         var parsedFromSource = YamlParser.parse(flowSource, Flow.class);
         var tenantId = runContext.flowInfo().tenantId();
-        var currentFlow = fetchFlowFromApi(kestraClient(runContext), tenantId, parsedFromSource.getNamespace(), parsedFromSource.getId());
+        var currentFlow = fetchFlowFromApi(runContext, kestraClient(runContext), tenantId, parsedFromSource.getNamespace(), parsedFromSource.getId());
 
         if (currentFlow == null) {
             // New flow — revision will be 1 after import
@@ -234,7 +235,7 @@ public class SyncFlows extends AbstractSyncTask<Flow, SyncFlows.Output> {
         if (source == null) {
             return "";
         }
-        return source.replaceAll("(?m)^revision:\\s*\\d+\\n?", "").replace("\r\n", "\n").strip();
+        return REVISION_LINE_PATTERN.matcher(source).replaceAll("").replace("\r\n", "\n").strip();
     }
 
     @Override
@@ -282,7 +283,7 @@ public class SyncFlows extends AbstractSyncTask<Flow, SyncFlows.Output> {
         kestraClient.flows().importFlows(tenantId, true, toNamedTempFile(parsed.getId() + ".yaml", flowSource.stripTrailing()));
 
         // Re-fetch from Kestra to get the authoritative revision after import
-        var updated = fetchFlowFromApi(kestraClient, tenantId, parsed.getNamespace(), parsed.getId());
+        var updated = fetchFlowFromApi(runContext, kestraClient, tenantId, parsed.getNamespace(), parsed.getId());
         return updated != null ? updated : FlowWithSource.of(parsed, flowSource);
     }
 
@@ -384,7 +385,7 @@ public class SyncFlows extends AbstractSyncTask<Flow, SyncFlows.Output> {
         }
     }
 
-    private FlowWithSource fetchFlowFromApi(KestraClient kestraClient, String tenantId, String namespace, String flowId) {
+    private FlowWithSource fetchFlowFromApi(RunContext runContext, KestraClient kestraClient, String tenantId, String namespace, String flowId) {
         try {
             var apiFlow = kestraClient.flows().flow(namespace, flowId, tenantId, true, null, false);
             return FlowWithSource.builder()
@@ -395,7 +396,15 @@ public class SyncFlows extends AbstractSyncTask<Flow, SyncFlows.Output> {
                 .source(apiFlow.getSource())
                 .build();
         } catch (ApiException e) {
-            // Flow does not exist yet, or could not be fetched
+            if (e.getCode() == 404) {
+                return null;
+            }
+            // Not a "does not exist" case: a permissions/API failure here would otherwise be silently
+            // misreported as the flow being ADDED, so surface it instead of swallowing it.
+            runContext.logger().warn(
+                "Failed to fetch flow {}.{} from the Kestra API (status {}): {}",
+                namespace, flowId, e.getCode(), e.getMessage()
+            );
             return null;
         }
     }

--- a/src/main/java/io/kestra/plugin/git/SyncFlows.java
+++ b/src/main/java/io/kestra/plugin/git/SyncFlows.java
@@ -209,9 +209,14 @@ public class SyncFlows extends AbstractSyncTask<Flow, SyncFlows.Output> {
         // Simulate: parse the source and determine if it differs from the current Kestra state
         var parsedFromSource = YamlParser.parse(flowSource, Flow.class);
         var tenantId = runContext.flowInfo().tenantId();
-        var currentFlow = fetchFlowFromApi(runContext, kestraClient(runContext), tenantId, parsedFromSource.getNamespace(), parsedFromSource.getId());
+        var lookup = fetchFlowFromApi(runContext, kestraClient(runContext), tenantId, parsedFromSource.getNamespace(), parsedFromSource.getId());
+        var currentFlow = lookup.flow();
 
         if (currentFlow == null) {
+            if (!lookup.resolved()) {
+                // Lookup failed for a reason other than "flow does not exist" — don't fabricate a revision
+                return FlowWithSource.of(parsedFromSource, flowSource);
+            }
             // New flow — revision will be 1 after import
             return simulatedFlow(parsedFromSource, flowSource, 1);
         }
@@ -225,6 +230,9 @@ public class SyncFlows extends AbstractSyncTask<Flow, SyncFlows.Output> {
         // Changed — simulate next revision
         int projectedRevision = currentFlow.getRevision() != null ? currentFlow.getRevision() + 1 : 1;
         return simulatedFlow(parsedFromSource, flowSource, projectedRevision);
+    }
+
+    private record FlowLookup(FlowWithSource flow, boolean resolved) {
     }
 
     private static FlowWithSource simulatedFlow(Flow parsedFromSource, String flowSource, int revision) {
@@ -283,7 +291,7 @@ public class SyncFlows extends AbstractSyncTask<Flow, SyncFlows.Output> {
         kestraClient.flows().importFlows(tenantId, true, toNamedTempFile(parsed.getId() + ".yaml", flowSource.stripTrailing()));
 
         // Re-fetch from Kestra to get the authoritative revision after import
-        var updated = fetchFlowFromApi(runContext, kestraClient, tenantId, parsed.getNamespace(), parsed.getId());
+        var updated = fetchFlowFromApi(runContext, kestraClient, tenantId, parsed.getNamespace(), parsed.getId()).flow();
         return updated != null ? updated : FlowWithSource.of(parsed, flowSource);
     }
 
@@ -385,27 +393,30 @@ public class SyncFlows extends AbstractSyncTask<Flow, SyncFlows.Output> {
         }
     }
 
-    private FlowWithSource fetchFlowFromApi(RunContext runContext, KestraClient kestraClient, String tenantId, String namespace, String flowId) {
+    private FlowLookup fetchFlowFromApi(RunContext runContext, KestraClient kestraClient, String tenantId, String namespace, String flowId) {
         try {
             var apiFlow = kestraClient.flows().flow(namespace, flowId, tenantId, true, null, false);
-            return FlowWithSource.builder()
-                .id(apiFlow.getId())
-                .namespace(apiFlow.getNamespace())
-                .revision(apiFlow.getRevision())
-                .tenantId(tenantId)
-                .source(apiFlow.getSource())
-                .build();
+            return new FlowLookup(
+                FlowWithSource.builder()
+                    .id(apiFlow.getId())
+                    .namespace(apiFlow.getNamespace())
+                    .revision(apiFlow.getRevision())
+                    .tenantId(tenantId)
+                    .source(apiFlow.getSource())
+                    .build(),
+                true
+            );
         } catch (ApiException e) {
             if (e.getCode() == 404) {
-                return null;
+                return new FlowLookup(null, true);
             }
-            // Only 404 means "flow does not exist" and is swallowed silently above; any other status is a
-            // real API/permissions failure, so log it and still return null (sync continues, flow treated as absent).
+            // Only 404 means "flow does not exist"; any other status is a real API/permissions failure that
+            // leaves the lookup unresolved, so callers must not assume the flow is absent.
             runContext.logger().warn(
                 "Failed to fetch flow {}.{} from the Kestra API (status {}): {}",
                 namespace, flowId, e.getCode(), e.getMessage()
             );
-            return null;
+            return new FlowLookup(null, false);
         }
     }
 

--- a/src/main/java/io/kestra/plugin/git/SyncFlows.java
+++ b/src/main/java/io/kestra/plugin/git/SyncFlows.java
@@ -232,9 +232,6 @@ public class SyncFlows extends AbstractSyncTask<Flow, SyncFlows.Output> {
         return simulatedFlow(parsedFromSource, flowSource, projectedRevision);
     }
 
-    private record FlowLookup(FlowWithSource flow, boolean resolved) {
-    }
-
     private static FlowWithSource simulatedFlow(Flow parsedFromSource, String flowSource, int revision) {
         return FlowWithSource.of(parsedFromSource, flowSource).toBuilder().revision(revision).build();
     }
@@ -465,6 +462,9 @@ public class SyncFlows extends AbstractSyncTask<Flow, SyncFlows.Output> {
         }
     }
 
+    private record FlowLookup(FlowWithSource flow, boolean resolved) {
+    }
+
     @SuperBuilder
     @Getter
     public static class SyncResult extends AbstractSyncTask.SyncResult {
@@ -473,7 +473,8 @@ public class SyncFlows extends AbstractSyncTask<Flow, SyncFlows.Output> {
 
         @Schema(
             title = "Flow revision",
-            description = "Revision of the flow after sync. May be absent if it could not be resolved from the Kestra API."
+            description = """
+                Revision of the flow after sync. May be absent if it could not be resolved from the Kestra API."""
         )
         private Integer revision;
     }

--- a/src/main/java/io/kestra/plugin/git/SyncFlows.java
+++ b/src/main/java/io/kestra/plugin/git/SyncFlows.java
@@ -399,8 +399,8 @@ public class SyncFlows extends AbstractSyncTask<Flow, SyncFlows.Output> {
             if (e.getCode() == 404) {
                 return null;
             }
-            // Not a "does not exist" case: a permissions/API failure here would otherwise be silently
-            // misreported as the flow being ADDED, so surface it instead of swallowing it.
+            // Only 404 means "flow does not exist" and is swallowed silently above; any other status is a
+            // real API/permissions failure, so log it and still return null (sync continues, flow treated as absent).
             runContext.logger().warn(
                 "Failed to fetch flow {}.{} from the Kestra API (status {}): {}",
                 namespace, flowId, e.getCode(), e.getMessage()

--- a/src/main/java/io/kestra/plugin/git/SyncFlows.java
+++ b/src/main/java/io/kestra/plugin/git/SyncFlows.java
@@ -208,25 +208,33 @@ public class SyncFlows extends AbstractSyncTask<Flow, SyncFlows.Output> {
         // Simulate: parse the source and determine if it differs from the current Kestra state
         var parsedFromSource = YamlParser.parse(flowSource, Flow.class);
         var tenantId = runContext.flowInfo().tenantId();
-        var currentFlow = fetchSingleFlow(kestraClient(runContext), tenantId, parsedFromSource.getNamespace(), parsedFromSource.getId());
+        var currentFlow = fetchFlowFromApi(kestraClient(runContext), tenantId, parsedFromSource.getNamespace(), parsedFromSource.getId());
 
         if (currentFlow == null) {
             // New flow — revision will be 1 after import
-            return parsedFromSource.toBuilder().revision(1).build();
+            return simulatedFlow(parsedFromSource, flowSource, 1);
         }
 
-        // Compare normalised source to detect changes
-        // Strip revision: from the exported source — the Kestra ZIP export injects it but git sources never have it
-        var normalised = flowSource.replace("\r\n", "\n").strip();
-        var currentSourceWithoutRevision = currentFlow.getSource().replaceAll("(?m)^revision:\\s*\\d+\\n?", "");
-        var currentNormalised = currentSourceWithoutRevision.replace("\r\n", "\n").strip();
-        if (normalised.equals(currentNormalised)) {
+        // Compare normalised source (some Kestra versions inject a leading revision: line into the fetched source; git sources never have it) to detect changes
+        if (normalizeSource(flowSource).equals(normalizeSource(currentFlow.getSource()))) {
             // Unchanged — return the current flow so wrapper detects UNCHANGED
             return currentFlow;
         }
 
         // Changed — simulate next revision
-        return parsedFromSource.toBuilder().revision(currentFlow.getRevision() + 1).build();
+        int projectedRevision = currentFlow.getRevision() != null ? currentFlow.getRevision() + 1 : 1;
+        return simulatedFlow(parsedFromSource, flowSource, projectedRevision);
+    }
+
+    private static FlowWithSource simulatedFlow(Flow parsedFromSource, String flowSource, int revision) {
+        return FlowWithSource.of(parsedFromSource, flowSource).toBuilder().revision(revision).build();
+    }
+
+    private static String normalizeSource(String source) {
+        if (source == null) {
+            return "";
+        }
+        return source.replaceAll("(?m)^revision:\\s*\\d+\\n?", "").replace("\r\n", "\n").strip();
     }
 
     @Override
@@ -270,13 +278,12 @@ public class SyncFlows extends AbstractSyncTask<Flow, SyncFlows.Output> {
             throw new FlowProcessingException("Invalid flow imported from Git (" + ref + "): " + flowValidated.getConstraints());
         }
 
-        var parsedId = YamlParser.parse(flowSource, Flow.class).getId();
-        kestraClient.flows().importFlows(tenantId, true, toNamedTempFile(parsedId + ".yaml", flowSource.stripTrailing()));
+        var parsed = YamlParser.parse(flowSource, Flow.class);
+        kestraClient.flows().importFlows(tenantId, true, toNamedTempFile(parsed.getId() + ".yaml", flowSource.stripTrailing()));
 
-        // Re-fetch from Kestra to get the updated revision
-        var parsedNamespace = YamlParser.parse(flowSource, Flow.class).getNamespace();
-        var updated = fetchSingleFlow(kestraClient, tenantId, parsedNamespace, parsedId);
-        return updated != null ? updated : YamlParser.parse(flowSource, Flow.class);
+        // Re-fetch from Kestra to get the authoritative revision after import
+        var updated = fetchFlowFromApi(kestraClient, tenantId, parsed.getNamespace(), parsed.getId());
+        return updated != null ? updated : FlowWithSource.of(parsed, flowSource);
     }
 
     private static String replaceNamespace(String renderedNamespace, URI uri, InputStream inputStream) throws IOException {
@@ -303,7 +310,8 @@ public class SyncFlows extends AbstractSyncTask<Flow, SyncFlows.Output> {
             syncState = SyncState.DELETED;
         } else if (flowBeforeUpdate == null) {
             syncState = SyncState.ADDED;
-        } else if (flowBeforeUpdate.getRevision().equals(Objects.requireNonNull(flowAfterUpdate).getRevision())) {
+        } else if (flowAfterUpdate != null && normalizeSource(flowBeforeUpdate.getSource()).equals(normalizeSource(flowAfterUpdate.getSource()))) {
+            // Source-based comparison: revision may be null when a flow is parsed from an export and cannot be used for diffing
             syncState = SyncState.UNCHANGED;
         } else {
             syncState = SyncState.UPDATED;
@@ -376,30 +384,18 @@ public class SyncFlows extends AbstractSyncTask<Flow, SyncFlows.Output> {
         }
     }
 
-    private FlowWithSource fetchSingleFlow(KestraClient kestraClient, String tenantId, String namespace, String flowId) {
+    private FlowWithSource fetchFlowFromApi(KestraClient kestraClient, String tenantId, String namespace, String flowId) {
         try {
-            byte[] zippedFlows = kestraClient.flows().exportFlowsByQuery(
-                tenantId,
-                List.of(
-                    new QueryFilter().field(QueryFilterField.NAMESPACE).operation(QueryFilterOp.EQUALS).value(namespace),
-                    new QueryFilter().field(QueryFilterField.ID).operation(QueryFilterOp.EQUALS).value(flowId)
-                )
-            );
-            try (
-                var bais = new ByteArrayInputStream(zippedFlows);
-                var zis = new ZipInputStream(bais)
-            ) {
-                ZipEntry entry;
-                while ((entry = zis.getNextEntry()) != null) {
-                    if (!entry.getName().endsWith(".yml") && !entry.getName().endsWith(".yaml")) {
-                        continue;
-                    }
-                    var yaml = new String(zis.readAllBytes(), StandardCharsets.UTF_8);
-                    return FlowWithSource.of(YamlParser.parse(yaml, Flow.class), yaml);
-                }
-            }
-            return null;
-        } catch (Exception e) {
+            var apiFlow = kestraClient.flows().flow(namespace, flowId, tenantId, true, null, false);
+            return FlowWithSource.builder()
+                .id(apiFlow.getId())
+                .namespace(apiFlow.getNamespace())
+                .revision(apiFlow.getRevision())
+                .tenantId(tenantId)
+                .source(apiFlow.getSource())
+                .build();
+        } catch (ApiException e) {
+            // Flow does not exist yet, or could not be fetched
             return null;
         }
     }
@@ -454,6 +450,11 @@ public class SyncFlows extends AbstractSyncTask<Flow, SyncFlows.Output> {
     public static class SyncResult extends AbstractSyncTask.SyncResult {
         private String flowId;
         private String namespace;
+
+        @Schema(
+            title = "Flow revision",
+            description = "Revision of the flow after sync. May be absent if it could not be resolved from the Kestra API."
+        )
         private Integer revision;
     }
 }

--- a/src/test/java/io/kestra/plugin/git/MockKestraApiServer.java
+++ b/src/test/java/io/kestra/plugin/git/MockKestraApiServer.java
@@ -2,13 +2,13 @@ package io.kestra.plugin.git;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
@@ -46,6 +46,8 @@ public class MockKestraApiServer implements AutoCloseable {
     private final HttpServer server;
     private final FlowRepositoryInterface flowRepo;
     private final DashboardRepositoryInterface dashboardRepo;
+    // Keyed by "namespace/id" -> forces GET /flows/{namespace}/{id} to fail with the given status, to exercise non-404 API failures
+    private final Map<String, Integer> forcedGetFlowStatuses = new ConcurrentHashMap<>();
 
     private MockKestraApiServer(FlowRepositoryInterface flowRepo, DashboardRepositoryInterface dashboardRepo) throws IOException {
         this.flowRepo = flowRepo;
@@ -82,6 +84,14 @@ public class MockKestraApiServer implements AutoCloseable {
         return "http://localhost:" + server.getAddress().getPort();
     }
 
+    /**
+     * Forces the next {@code GET /flows/{namespace}/{id}} calls for the given flow to fail with the given
+     * non-404 HTTP status, to exercise how callers handle a real API/permissions failure.
+     */
+    public void forceGetFlowStatus(String namespace, String flowId, int status) {
+        forcedGetFlowStatuses.put(namespace + "/" + flowId, status);
+    }
+
     @Override
     public void close() {
         server.stop(0);
@@ -91,7 +101,8 @@ public class MockKestraApiServer implements AutoCloseable {
 
     private void registerHandlers() {
         // flows: export, import, validate, delete
-        server.createContext("/api/v1/", exchange -> {
+        server.createContext("/api/v1/", exchange ->
+        {
             var path = exchange.getRequestURI().getPath();
             var method = exchange.getRequestMethod();
 
@@ -338,6 +349,13 @@ public class MockKestraApiServer implements AutoCloseable {
         var namespace = decode(parts[5]);
         var flowId = decode(parts[6]);
 
+        Integer forcedStatus = forcedGetFlowStatuses.get(namespace + "/" + flowId);
+        if (forcedStatus != null) {
+            exchange.sendResponseHeaders(forcedStatus, -1);
+            exchange.close();
+            return;
+        }
+
         var match = flowRepo.findByNamespaceWithSource(tenantId, namespace).stream()
             .filter(f -> flowId.equals(f.getId()))
             .findFirst();
@@ -350,12 +368,14 @@ public class MockKestraApiServer implements AutoCloseable {
 
         var flow = match.get();
         try {
-            var json = JacksonMapper.ofJson().writeValueAsString(Map.of(
-                "id", flow.getId(),
-                "namespace", flow.getNamespace(),
-                "revision", flow.getRevision() != null ? flow.getRevision() : 1,
-                "source", flow.getSource() != null ? flow.getSource() : ""
-            ));
+            var json = JacksonMapper.ofJson().writeValueAsString(
+                Map.of(
+                    "id", flow.getId(),
+                    "namespace", flow.getNamespace(),
+                    "revision", flow.getRevision() != null ? flow.getRevision() : 1,
+                    "source", flow.getSource() != null ? flow.getSource() : ""
+                )
+            );
             sendJson(exchange, 200, json);
         } catch (Exception e) {
             sendJson(exchange, 500, "{\"error\":\"serialization failed\"}");
@@ -412,12 +432,13 @@ public class MockKestraApiServer implements AutoCloseable {
         var sb = new StringBuilder("{\"results\":[");
         for (int i = 0; i < dashboards.size(); i++) {
             var d = dashboards.get(i);
-            if (i > 0) sb.append(",");
+            if (i > 0)
+                sb.append(",");
             // Include a non-null updated timestamp so production code can compare revisions
             var updatedTs = d.getUpdated() != null ? d.getUpdated().toString() : "1970-01-01T00:00:00Z";
             sb.append("{\"id\":\"").append(d.getId())
-              .append("\",\"title\":\"").append(d.getId())
-              .append("\",\"updated\":\"").append(updatedTs).append("\"}");
+                .append("\",\"title\":\"").append(d.getId())
+                .append("\",\"updated\":\"").append(updatedTs).append("\"}");
         }
         sb.append("],\"total\":").append(dashboards.size()).append("}");
         sendJson(exchange, 200, sb.toString());
@@ -483,9 +504,11 @@ public class MockKestraApiServer implements AutoCloseable {
                     .findFirst()
                     .orElse(null);
                 java.time.Instant updated;
-                if (existing != null
-                    && existing.getSourceCode() != null
-                    && existing.getSourceCode().strip().equals(yamlBody.strip())) {
+                if (
+                    existing != null
+                        && existing.getSourceCode() != null
+                        && existing.getSourceCode().strip().equals(yamlBody.strip())
+                ) {
                     // Same content — preserve existing timestamp (use EPOCH if null so handleGetDashboardYaml fallback matches)
                     updated = existing.getUpdated() != null ? existing.getUpdated() : java.time.Instant.EPOCH;
                 } else {
@@ -605,7 +628,8 @@ public class MockKestraApiServer implements AutoCloseable {
                 yamlBuilder.setLength(0);
                 continue;
             }
-            if (!inPart) continue;
+            if (!inPart)
+                continue;
             if (!pastHeaders) {
                 if (line.isBlank()) {
                     pastHeaders = true;

--- a/src/test/java/io/kestra/plugin/git/MockKestraApiServer.java
+++ b/src/test/java/io/kestra/plugin/git/MockKestraApiServer.java
@@ -104,6 +104,8 @@ public class MockKestraApiServer implements AutoCloseable {
                     handleValidateFlows(exchange);
                 } else if (path.contains("/flows/") && "DELETE".equals(method) && !path.contains("/flows/delete")) {
                     handleDeleteFlow(exchange);
+                } else if (path.contains("/flows/") && "GET".equals(method) && !path.contains("/flows/export")) {
+                    handleGetFlow(exchange);
                 } else if (path.contains("/namespaces/") && "GET".equals(method) && !path.contains("/secrets") && !path.contains("/plugindefaults") && !path.contains("/inherited")) {
                     handleGetNamespace(exchange);
                 } else if (path.contains("/dashboards") && "GET".equals(method) && !path.contains("/charts") && !path.contains("/export")) {
@@ -307,6 +309,57 @@ public class MockKestraApiServer implements AutoCloseable {
 
         exchange.sendResponseHeaders(200, -1);
         exchange.close();
+    }
+
+    /**
+     * GET /api/v1/{tenantId}/flows/{namespace}/{id}?source=&revision=&allowDeleted=
+     * Returns the current flow (with source) from the in-memory repo, or 404 if it doesn't exist.
+     * Used by SyncFlows/SyncFlow to fetch the authoritative revision, avoiding the ZIP-export revision gap.
+     */
+    private void handleGetFlow(HttpExchange exchange) throws IOException {
+        exchange.getRequestBody().readAllBytes();
+
+        if (flowRepo == null) {
+            exchange.sendResponseHeaders(404, -1);
+            exchange.close();
+            return;
+        }
+
+        var path = exchange.getRequestURI().getPath();
+        var parts = path.split("/");
+        // parts[0]="" [1]="api" [2]="v1" [3]=tenant [4]="flows" [5]=namespace [6]=id
+        if (parts.length < 7) {
+            exchange.sendResponseHeaders(404, -1);
+            exchange.close();
+            return;
+        }
+
+        var tenantId = decode(parts[3]);
+        var namespace = decode(parts[5]);
+        var flowId = decode(parts[6]);
+
+        var match = flowRepo.findByNamespaceWithSource(tenantId, namespace).stream()
+            .filter(f -> flowId.equals(f.getId()))
+            .findFirst();
+
+        if (match.isEmpty()) {
+            exchange.sendResponseHeaders(404, -1);
+            exchange.close();
+            return;
+        }
+
+        var flow = match.get();
+        try {
+            var json = JacksonMapper.ofJson().writeValueAsString(Map.of(
+                "id", flow.getId(),
+                "namespace", flow.getNamespace(),
+                "revision", flow.getRevision() != null ? flow.getRevision() : 1,
+                "source", flow.getSource() != null ? flow.getSource() : ""
+            ));
+            sendJson(exchange, 200, json);
+        } catch (Exception e) {
+            sendJson(exchange, 500, "{\"error\":\"serialization failed\"}");
+        }
     }
 
     /**

--- a/src/test/java/io/kestra/plugin/git/SyncFlowsContainerTest.java
+++ b/src/test/java/io/kestra/plugin/git/SyncFlowsContainerTest.java
@@ -1,15 +1,20 @@
 package io.kestra.plugin.git;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.type.TypeReference;
 
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.DefaultRunContext;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.sdk.model.Flow;
 import io.micronaut.context.annotation.Value;
 
@@ -32,6 +37,7 @@ import static org.hamcrest.Matchers.*;
 public class SyncFlowsContainerTest extends AbstractKestraContainerTest {
 
     private static final String TARGET_NAMESPACE = "io.kestra.tests.container";
+    private static final String TARGET_NAMESPACE_TWICE = "io.kestra.tests.container.twice";
     private static final String REPO_URL = "https://github.com/kestra-io/unit-tests";
     private static final String BRANCH = "sync";
     private static final String GIT_DIRECTORY = "to_clone/_flows";
@@ -45,7 +51,7 @@ public class SyncFlowsContainerTest extends AbstractKestraContainerTest {
 
     @Test
     void syncFlowsFromGit_shouldLandFlowsInKestra() throws Exception {
-        var runContext = buildRunContext();
+        var runContext = buildRunContext(TARGET_NAMESPACE);
 
         var task = SyncFlows.builder()
             .url(Property.ofValue(REPO_URL))
@@ -67,12 +73,46 @@ public class SyncFlowsContainerTest extends AbstractKestraContainerTest {
         assertThat("at least one flow must have been synced to the target namespace", flows, not(empty()));
     }
 
-    private RunContext buildRunContext() {
+    /**
+     * Regression test for https://github.com/kestra-io/plugin-git/issues/327: running SyncFlows twice in a row
+     * against the same namespace used to NPE on the second run because the "before" flow state (parsed from
+     * Kestra's export ZIP) never carries a revision. The second run must succeed and report every flow UNCHANGED.
+     */
+    @Test
+    void syncFlowsTwice_shouldReportUnchangedOnSecondRun() throws Exception {
+        var task = SyncFlows.builder()
+            .url(Property.ofValue(REPO_URL))
+            .username(Property.ofValue(gitPat))
+            .password(Property.ofValue(gitPat))
+            .branch(Property.ofValue(BRANCH))
+            .gitDirectory(Property.ofValue(GIT_DIRECTORY))
+            .targetNamespace(Property.ofValue(TARGET_NAMESPACE_TWICE))
+            .includeChildNamespaces(Property.ofValue(false))
+            .delete(Property.ofValue(false))
+            .kestraUrl(Property.ofValue(kestraUrl))
+            .build();
+
+        SyncFlows.Output firstOutput = task.run(buildRunContext(TARGET_NAMESPACE_TWICE));
+        assertThat("diff file URI must be present on first run", firstOutput.getFlows(), notNullValue());
+
+        var secondRunContext = buildRunContext(TARGET_NAMESPACE_TWICE);
+        SyncFlows.Output secondOutput = task.run(secondRunContext);
+
+        var diffLines = IOUtils.toString(secondRunContext.storage().getFile(secondOutput.diffFileUri()), StandardCharsets.UTF_8).lines().toList();
+        assertThat("second run must produce a diff", diffLines, not(empty()));
+
+        for (var line : diffLines) {
+            Map<String, Object> diff = JacksonMapper.ofIon().readValue(line, new TypeReference<Map<String, Object>>() {});
+            assertThat("flow " + diff.get("flowId") + " should be UNCHANGED on second run", diff.get("syncState"), is("UNCHANGED"));
+        }
+    }
+
+    private RunContext buildRunContext(String namespace) {
         var rc = runContextFactory.of(
             Map.of(
                 "flow", Map.of(
                     "tenantId", "main",
-                    "namespace", TARGET_NAMESPACE,
+                    "namespace", namespace,
                     "id", "sync-flows-container-test"
                 )
             )

--- a/src/test/java/io/kestra/plugin/git/SyncFlowsTest.java
+++ b/src/test/java/io/kestra/plugin/git/SyncFlowsTest.java
@@ -746,24 +746,28 @@ public class SyncFlowsTest extends AbstractGitTest {
         List<LogEntry> logs = new CopyOnWriteArrayList<>();
         logQueue.addListener(logs::add);
 
+        // mockRunContext (rather than the Map-based runContext() helper) is required here: it wires a real
+        // task/execution context whose logger actually publishes to logQueue, unlike a bare RunContextLogger.
         SyncFlows task = SyncFlows.builder()
-            .url(Property.ofExpression("{{url}}"))
-            .username(Property.ofExpression("{{pat}}"))
-            .password(Property.ofExpression("{{pat}}"))
-            .branch(Property.ofExpression("{{branch}}"))
-            .gitDirectory(Property.ofExpression("{{gitDirectory}}"))
-            .targetNamespace(Property.ofExpression("{{namespace}}"))
+            .id("sync-flows")
+            .type(SyncFlows.class.getName())
+            .url(Property.ofValue(repositoryUrl))
+            .username(Property.ofValue(pat))
+            .password(Property.ofValue(pat))
+            .branch(Property.ofValue(BRANCH))
+            .gitDirectory(Property.ofValue(GIT_DIRECTORY))
+            .targetNamespace(Property.ofValue(NAMESPACE))
             .includeChildNamespaces(Property.ofValue(true))
             .kestraUrl(Property.ofValue(server.url()))
             .build();
 
         // Establish a baseline: "unchanged-flow" now exists identically in Git and Kestra
-        task.run(runContext());
+        task.run(TestsUtils.mockRunContext(TENANT_ID, runContextFactory, task, Collections.emptyMap()));
 
         server.forceGetFlowStatus(NAMESPACE, "unchanged-flow", 500);
 
         SyncFlows dryRunTask = task.toBuilder().dryRun(Property.ofValue(true)).build();
-        RunContext dryRunContext = runContext();
+        RunContext dryRunContext = TestsUtils.mockRunContext(TENANT_ID, runContextFactory, dryRunTask, Collections.emptyMap());
         SyncFlows.Output dryOutput = dryRunTask.run(dryRunContext);
 
         // Behavior is preserved (no exception, still reported as UNCHANGED since the source content didn't change)

--- a/src/test/java/io/kestra/plugin/git/SyncFlowsTest.java
+++ b/src/test/java/io/kestra/plugin/git/SyncFlowsTest.java
@@ -6,6 +6,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
@@ -15,17 +16,20 @@ import org.eclipse.jgit.api.Git;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.event.Level;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 
 import io.kestra.core.exceptions.FlowProcessingException;
 import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.executions.LogEntry;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.FlowId;
 import io.kestra.core.models.flows.FlowWithSource;
 import io.kestra.core.models.flows.GenericFlow;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.GenericTask;
+import io.kestra.core.queues.DispatchQueueInterface;
 import io.kestra.core.repositories.FlowRepositoryInterface;
 import io.kestra.core.runners.DefaultRunContext;
 import io.kestra.core.runners.RunContext;
@@ -33,6 +37,7 @@ import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.tenant.TenantService;
 import io.kestra.core.utils.Rethrow;
+import io.kestra.core.utils.TestsUtils;
 
 import jakarta.inject.Inject;
 
@@ -57,6 +62,9 @@ public class SyncFlowsTest extends AbstractGitTest {
 
     @Inject
     private FlowRepositoryInterface flowRepositoryInterface;
+
+    @Inject
+    private DispatchQueueInterface<LogEntry> logQueue;
 
     private MockKestraApiServer server;
 
@@ -725,6 +733,51 @@ public class SyncFlowsTest extends AbstractGitTest {
         Map<String, Object> diff = findDiffByFlowId(secondRunContext, secondOutput.diffFileUri(), "unchanged-flow");
         assertThat(diff.get("syncState"), is("UPDATED"));
         assertThat(diff.get("revision"), is(revisionAfterManualEdit + 1));
+    }
+
+    /**
+     * A non-404 failure (e.g. 403/500) when re-fetching a flow's authoritative state must not be silently treated
+     * as "the flow does not exist" without a trace: it must be logged so a real API/permissions failure is visible
+     * rather than misreported as the flow being newly ADDED.
+     */
+    @Test
+    void dryRun_whenFlowApiFailsWithNon404Status_shouldLogWarningAndNotThrow() throws Exception {
+        List<LogEntry> logs = new CopyOnWriteArrayList<>();
+        logQueue.addListener(logs::add);
+
+        SyncFlows task = SyncFlows.builder()
+            .url(Property.ofExpression("{{url}}"))
+            .username(Property.ofExpression("{{pat}}"))
+            .password(Property.ofExpression("{{pat}}"))
+            .branch(Property.ofExpression("{{branch}}"))
+            .gitDirectory(Property.ofExpression("{{gitDirectory}}"))
+            .targetNamespace(Property.ofExpression("{{namespace}}"))
+            .includeChildNamespaces(Property.ofValue(true))
+            .kestraUrl(Property.ofValue(server.url()))
+            .build();
+
+        // Establish a baseline: "unchanged-flow" now exists identically in Git and Kestra
+        task.run(runContext());
+
+        server.forceGetFlowStatus(NAMESPACE, "unchanged-flow", 500);
+
+        SyncFlows dryRunTask = task.toBuilder().dryRun(Property.ofValue(true)).build();
+        RunContext dryRunContext = runContext();
+        SyncFlows.Output dryOutput = dryRunTask.run(dryRunContext);
+
+        // Behavior is preserved (no exception), but the failure must not be silently misreported without a trace
+        Map<String, Object> diff = findDiffByFlowId(dryRunContext, dryOutput.diffFileUri(), "unchanged-flow");
+        assertThat(diff.get("syncState"), is("ADDED"));
+
+        List<LogEntry> warnLogs = TestsUtils.awaitLogs(
+            logs,
+            logEntry -> logEntry.getLevel().equals(Level.WARN) &&
+                logEntry.getMessage().contains(NAMESPACE) &&
+                logEntry.getMessage().contains("unchanged-flow") &&
+                logEntry.getMessage().contains("500"),
+            1
+        );
+        assertThat(warnLogs, hasSize(1));
     }
 
     /**

--- a/src/test/java/io/kestra/plugin/git/SyncFlowsTest.java
+++ b/src/test/java/io/kestra/plugin/git/SyncFlowsTest.java
@@ -635,6 +635,181 @@ public class SyncFlowsTest extends AbstractGitTest {
         assertThat(ex.getMessage(), containsString("demo-invalid-flow"));
     }
 
+    /**
+     * Regression test for https://github.com/kestra-io/plugin-git/issues/327: on the second run, the "before" flow
+     * state is parsed from Kestra's export ZIP, which never carries a revision. Running twice in a row must not NPE
+     * and must report every flow UNCHANGED since nothing changed on either side between the two runs.
+     */
+    @Test
+    void runTwice_shouldReportUnchangedOnSecondRun() throws Exception {
+        SyncFlows task = SyncFlows.builder()
+            .url(Property.ofExpression("{{url}}"))
+            .username(Property.ofExpression("{{pat}}"))
+            .password(Property.ofExpression("{{pat}}"))
+            .branch(Property.ofExpression("{{branch}}"))
+            .gitDirectory(Property.ofExpression("{{gitDirectory}}"))
+            .targetNamespace(Property.ofExpression("{{namespace}}"))
+            .includeChildNamespaces(Property.ofValue(true))
+            .kestraUrl(Property.ofValue(server.url()))
+            .build();
+
+        task.run(runContext());
+
+        RunContext secondRunContext = runContext();
+        SyncFlows.Output secondOutput = task.run(secondRunContext);
+
+        assertAllDiffsHaveSyncState(secondRunContext, secondOutput.diffFileUri(), "UNCHANGED");
+    }
+
+    /**
+     * Same regression as above but for the dry-run path (SyncFlows.java line ~229, `currentFlow.getRevision() + 1`):
+     * a flow edited directly in Kestra (out of band, not through Git) must be projected as UPDATED with an
+     * incremented revision on a dry run, without throwing.
+     */
+    @Test
+    void dryRun_afterManualEditInKestra_shouldProjectIncrementedRevisionWithoutThrowing() throws Exception {
+        SyncFlows task = SyncFlows.builder()
+            .url(Property.ofExpression("{{url}}"))
+            .username(Property.ofExpression("{{pat}}"))
+            .password(Property.ofExpression("{{pat}}"))
+            .branch(Property.ofExpression("{{branch}}"))
+            .gitDirectory(Property.ofExpression("{{gitDirectory}}"))
+            .targetNamespace(Property.ofExpression("{{namespace}}"))
+            .includeChildNamespaces(Property.ofValue(true))
+            .kestraUrl(Property.ofValue(server.url()))
+            .build();
+
+        // Establish a baseline by actually syncing once
+        task.run(runContext());
+        int revisionAfterManualEdit = manuallyEditFlowInKestra("unchanged-flow");
+
+        SyncFlows dryRunTask = task.toBuilder().dryRun(Property.ofValue(true)).build();
+        RunContext dryRunContext = runContext();
+        SyncFlows.Output dryOutput = dryRunTask.run(dryRunContext);
+
+        Map<String, Object> diff = findDiffByFlowId(dryRunContext, dryOutput.diffFileUri(), "unchanged-flow");
+        assertThat(diff.get("syncState"), is("UPDATED"));
+        assertThat(diff.get("revision"), is(revisionAfterManualEdit + 1));
+
+        // Dry run must not have touched Kestra's state
+        FlowWithSource stillManuallyEdited = flowRepositoryInterface.findByNamespaceWithSource(TENANT_ID, NAMESPACE).stream()
+            .filter(f -> f.getId().equals("unchanged-flow"))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("Flow 'unchanged-flow' should still exist after a dry run"));
+        assertThat(stillManuallyEdited.getRevision(), is(revisionAfterManualEdit));
+    }
+
+    /**
+     * A flow edited directly in Kestra (out of band, not through Git) must be detected as UPDATED and re-synced
+     * from Git on the next (non-dry) run, with the revision incremented once more by the re-import.
+     */
+    @Test
+    void runTwice_withFlowManuallyEditedInKestra_shouldReportUpdatedWithIncrementedRevision() throws Exception {
+        SyncFlows task = SyncFlows.builder()
+            .url(Property.ofExpression("{{url}}"))
+            .username(Property.ofExpression("{{pat}}"))
+            .password(Property.ofExpression("{{pat}}"))
+            .branch(Property.ofExpression("{{branch}}"))
+            .gitDirectory(Property.ofExpression("{{gitDirectory}}"))
+            .targetNamespace(Property.ofExpression("{{namespace}}"))
+            .includeChildNamespaces(Property.ofValue(true))
+            .kestraUrl(Property.ofValue(server.url()))
+            .build();
+
+        task.run(runContext());
+        int revisionAfterManualEdit = manuallyEditFlowInKestra("unchanged-flow");
+
+        RunContext secondRunContext = runContext();
+        SyncFlows.Output secondOutput = task.run(secondRunContext);
+
+        Map<String, Object> diff = findDiffByFlowId(secondRunContext, secondOutput.diffFileUri(), "unchanged-flow");
+        assertThat(diff.get("syncState"), is("UPDATED"));
+        assertThat(diff.get("revision"), is(revisionAfterManualEdit + 1));
+    }
+
+    /**
+     * Directly exercises SyncFlows.wrapper() with a null revision on either side to lock the fix: the sync state
+     * must be derived from source equality, never from a nullable revision comparison.
+     */
+    @Test
+    void wrapper_withNullRevisionOnEitherSide_shouldNotThrowAndCompareBySource() {
+        SyncFlows task = SyncFlows.builder()
+            .url(Property.ofExpression("{{url}}"))
+            .branch(Property.ofExpression("{{branch}}"))
+            .gitDirectory(Property.ofExpression("{{gitDirectory}}"))
+            .targetNamespace(Property.ofExpression("{{namespace}}"))
+            .kestraUrl(Property.ofValue(server.url()))
+            .build();
+
+        String source = "id: some-flow\nnamespace: " + NAMESPACE + "\n";
+        FlowWithSource beforeWithNullRevision = FlowWithSource.builder()
+            .id("some-flow")
+            .namespace(NAMESPACE)
+            .revision(null)
+            .source(source)
+            .build();
+
+        FlowWithSource sameSourceDifferentRevision = FlowWithSource.builder()
+            .id("some-flow")
+            .namespace(NAMESPACE)
+            .revision(3)
+            .source(source)
+            .build();
+
+        AbstractSyncTask.SyncResult unchanged = task.wrapper(
+            runContext(), "to_clone/_flows", NAMESPACE, URI.create("/some-flow.yml"), beforeWithNullRevision, sameSourceDifferentRevision
+        );
+        assertThat(unchanged.getSyncState(), is(AbstractSyncTask.SyncState.UNCHANGED));
+
+        FlowWithSource changedSource = FlowWithSource.builder()
+            .id("some-flow")
+            .namespace(NAMESPACE)
+            .revision(null)
+            .source(source + "description: changed\n")
+            .build();
+
+        AbstractSyncTask.SyncResult updated = task.wrapper(
+            runContext(), "to_clone/_flows", NAMESPACE, URI.create("/some-flow.yml"), beforeWithNullRevision, changedSource
+        );
+        assertThat(updated.getSyncState(), is(AbstractSyncTask.SyncState.UPDATED));
+    }
+
+    /**
+     * Simulates a change made directly in Kestra (not through Git): updates the flow's source in place and
+     * returns the resulting revision.
+     */
+    private int manuallyEditFlowInKestra(String flowId) {
+        FlowWithSource existing = flowRepositoryInterface.findByNamespaceWithSource(TENANT_ID, NAMESPACE).stream()
+            .filter(f -> f.getId().equals(flowId))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("Flow '" + flowId + "' was expected to exist after the first sync"));
+
+        String editedSource = existing.getSource().replace("Hello from old-task", "Hello from manually-edited-task");
+        GenericFlow edited = GenericFlow.fromYaml(TENANT_ID, editedSource);
+        FlowWithSource updated = flowRepositoryInterface.update(edited.toBuilder().source(editedSource).build(), existing);
+        return updated.getRevision();
+    }
+
+    private static Map<String, Object> findDiffByFlowId(RunContext runContext, URI diffFileUri, String flowId) throws IOException {
+        String diffSummary = IOUtils.toString(runContext.storage().getFile(diffFileUri), StandardCharsets.UTF_8);
+        return diffSummary.lines()
+            .map(Rethrow.throwFunction(diff -> JacksonMapper.ofIon().readValue(diff, new TypeReference<Map<String, Object>>() {
+            })))
+            .filter(diff -> flowId.equals(diff.get("flowId")))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("No diff entry found for flow '" + flowId + "'"));
+    }
+
+    private static void assertAllDiffsHaveSyncState(RunContext runContext, URI diffFileUri, String expectedSyncState) throws IOException {
+        String diffSummary = IOUtils.toString(runContext.storage().getFile(diffFileUri), StandardCharsets.UTF_8);
+        List<Map<String, Object>> diffMaps = diffSummary.lines()
+            .map(Rethrow.throwFunction(diff -> JacksonMapper.ofIon().readValue(diff, new TypeReference<Map<String, Object>>() {
+            })))
+            .toList();
+        assertThat(diffMaps, not(empty()));
+        diffMaps.forEach(diff -> assertThat("flow " + diff.get("flowId") + " should be " + expectedSyncState, diff.get("syncState"), is(expectedSyncState)));
+    }
+
     private List<Map<String, Object>> defaultCaseDiffs(boolean includeSubNamespaces, boolean dryRun, Map<String, Object>... additionalDiffs) {
         List<Map<String, Object>> diffs = new ArrayList<>(
             List.of(

--- a/src/test/java/io/kestra/plugin/git/SyncFlowsTest.java
+++ b/src/test/java/io/kestra/plugin/git/SyncFlowsTest.java
@@ -786,6 +786,39 @@ public class SyncFlowsTest extends AbstractGitTest {
     }
 
     /**
+     * When the single-flow re-fetch fails for a reason other than 404, the lookup is unresolved: the dry-run diff
+     * must not fabricate revision 1 (which would misreport an existing flow as freshly created). It must report
+     * no revision at all, per the SyncResult.revision contract which documents an absent revision as valid.
+     */
+    @Test
+    void dryRun_whenFlowApiFailsWithNon404Status_shouldReportNoRevisionInsteadOfFabricatingOne() throws Exception {
+        SyncFlows task = SyncFlows.builder()
+            .id("sync-flows")
+            .type(SyncFlows.class.getName())
+            .url(Property.ofValue(repositoryUrl))
+            .username(Property.ofValue(pat))
+            .password(Property.ofValue(pat))
+            .branch(Property.ofValue(BRANCH))
+            .gitDirectory(Property.ofValue(GIT_DIRECTORY))
+            .targetNamespace(Property.ofValue(NAMESPACE))
+            .includeChildNamespaces(Property.ofValue(true))
+            .kestraUrl(Property.ofValue(server.url()))
+            .build();
+
+        // Establish a baseline: "unchanged-flow" now exists identically in Git and Kestra, at a known revision
+        task.run(TestsUtils.mockRunContext(TENANT_ID, runContextFactory, task, Collections.emptyMap()));
+
+        server.forceGetFlowStatus(NAMESPACE, "unchanged-flow", 500);
+
+        SyncFlows dryRunTask = task.toBuilder().dryRun(Property.ofValue(true)).build();
+        RunContext dryRunContext = TestsUtils.mockRunContext(TENANT_ID, runContextFactory, dryRunTask, Collections.emptyMap());
+        SyncFlows.Output dryOutput = dryRunTask.run(dryRunContext);
+
+        Map<String, Object> diff = findDiffByFlowId(dryRunContext, dryOutput.diffFileUri(), "unchanged-flow");
+        assertThat(diff.get("revision"), is(nullValue()));
+    }
+
+    /**
      * Directly exercises SyncFlows.wrapper() with a null revision on either side to lock the fix: the sync state
      * must be derived from source equality, never from a nullable revision comparison.
      */

--- a/src/test/java/io/kestra/plugin/git/SyncFlowsTest.java
+++ b/src/test/java/io/kestra/plugin/git/SyncFlowsTest.java
@@ -737,8 +737,9 @@ public class SyncFlowsTest extends AbstractGitTest {
 
     /**
      * A non-404 failure (e.g. 403/500) when re-fetching a flow's authoritative state must not be silently treated
-     * as "the flow does not exist" without a trace: it must be logged so a real API/permissions failure is visible
-     * rather than misreported as the flow being newly ADDED.
+     * as "the flow does not exist" without a trace: it must be logged so a real API/permissions failure is visible.
+     * The sync state itself is still derived from source comparison (unaffected by the single-flow API failure,
+     * since the "before" state comes from the namespace export, not from this call), so it stays UNCHANGED here.
      */
     @Test
     void dryRun_whenFlowApiFailsWithNon404Status_shouldLogWarningAndNotThrow() throws Exception {
@@ -765,9 +766,9 @@ public class SyncFlowsTest extends AbstractGitTest {
         RunContext dryRunContext = runContext();
         SyncFlows.Output dryOutput = dryRunTask.run(dryRunContext);
 
-        // Behavior is preserved (no exception), but the failure must not be silently misreported without a trace
+        // Behavior is preserved (no exception, still reported as UNCHANGED since the source content didn't change)
         Map<String, Object> diff = findDiffByFlowId(dryRunContext, dryOutput.diffFileUri(), "unchanged-flow");
-        assertThat(diff.get("syncState"), is("ADDED"));
+        assertThat(diff.get("syncState"), is("UNCHANGED"));
 
         List<LogEntry> warnLogs = TestsUtils.awaitLogs(
             logs,


### PR DESCRIPTION
## Summary

- `SyncFlows` NPE'd on any run after the first: the "before" flow state is parsed from Kestra's export ZIP, which never carries a `revision`, and the sync-state decision unconditionally dereferenced `flowBeforeUpdate.getRevision()`.
- `wrapper()` now derives ADDED/UPDATED/UNCHANGED/DELETED from normalized source-text equality instead of revision arithmetic, so a null revision on either side can never throw.
- Replaced the ZIP-export-based single-flow lookup (`fetchSingleFlow`) with a direct call to the single-flow API endpoint (`flows().flow(...)`, same one used by `SyncFlow`), which returns an authoritative, non-null revision.
- `SyncResult.revision` is now documented as possibly absent when it can't be resolved.
- Added a `GET /flows/{namespace}/{id}` handler to the test `MockKestraApiServer` to back the new API call.
- Added regression tests: a unit test locking `wrapper()`'s null-revision/source-based behavior, container/mock tests running `SyncFlows` twice (dry-run and non-dry-run) against the same namespace, and a case where a flow is manually edited in Kestra between two runs.

closes: https://github.com/kestra-io/plugin-git/issues/327

## Test plan

- [x] `rtk test ./gradlew test` — compiles cleanly; the new `wrapper_withNullRevisionOnEitherSide_shouldNotThrowAndCompareBySource`, `shouldThrowOnInvalidFlowFromGit`, and `shouldIgnoreInvalidFlowFromGit` tests pass locally. The other `SyncFlowsTest`/`SyncFlowsContainerTest` cases (including the new "run twice" regression tests) require a real GitHub PAT (`GH_PERSONAL_TOKEN`) to clone the external `kestra-io/unit-tests` fixture repo and a live Kestra container — both unavailable in this sandbox, and this dependency is pre-existing (every git-network test in the repo fails identically here, before this change too). These run in CI via `secrets: inherit`.
- [ ] `./gradlew shadowJar` builds
- [ ] Manually verify: run `SyncFlows` against a real Kestra instance twice in a row on the same flow — second run must succeed and report `UNCHANGED`

---
*[View as Artifact](https://claude.ai/code/artifact/1ed9d84d-b37f-45f2-a46f-80b5a29f250f)*