### PR TITLE
build(deps): bump plugin-git-lib to 1.0.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     compileOnly group: "io.kestra", name: "script", version: kestraVersion
 
     // shared Git kernel (also brings jgit and kestra-api-client transitively as `api`)
-    api 'io.kestra.plugin:plugin-git-lib:1.0.0'
+    api 'io.kestra.plugin:plugin-git-lib:1.0.2'
 }
 
 
@@ -103,7 +103,7 @@ dependencies {
     testImplementation "org.testcontainers:junit-jupiter:1.21.4"
 
     // shared Gitea/Kestra-container test scaffolding and mock Kestra API server
-    testImplementation testFixtures('io.kestra.plugin:plugin-git-lib:1.0.0')
+    testImplementation testFixtures('io.kestra.plugin:plugin-git-lib:1.0.2')
 }
 
 /**********************************************************************************************************************\


### PR DESCRIPTION
This replaces what this PR originally contained.

- The `auth.auto: false` opt-out was first implemented here, in this repo's own `AbstractKestraTask`. [#342](https://github.com/kestra-io/plugin-git/pull/342) then moved that whole hierarchy into the shared [plugin-git-lib](https://github.com/kestra-io/plugin-git-lib) kernel and deleted the file, so the original diff could only have been "rebased" by resurrecting classes the refactor removed. The feature now ships from the lib, and this repo only has to move its pin.
- `1.0.0` -> `1.0.2`, on both the `api` dependency and the `testFixtures` one, bringing:
  - [plugin-git-lib#7](https://github.com/kestra-io/plugin-git-lib/pull/7) — `auth.auto: false` with no credential set builds a client that sends no `Authorization` header, instead of failing with "No authentication method provided". Leaving `auth.auto` on still fails fast, so only an explicit opt-out reaches the unauthenticated client.
  - `fix(push)` — a `DELETE_ONLY` push mode, to stage removals without re-pushing.
  - `fix` — sync tasks now fail when the requested branch does not exist on the remote.
