### PR TITLE
fix(SyncFlow): fail when the requested branch does not exist

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     compileOnly group: "io.kestra", name: "script", version: kestraVersion
 
     // shared Git kernel (also brings jgit and kestra-api-client transitively as `api`)
-    api 'io.kestra.plugin:plugin-git-lib:1.0.0'
+    api 'io.kestra.plugin:plugin-git-lib:1.0.2'
 }
 
 
@@ -103,7 +103,7 @@ dependencies {
     testImplementation "org.testcontainers:junit-jupiter:1.21.4"
 
     // shared Gitea/Kestra-container test scaffolding and mock Kestra API server
-    testImplementation testFixtures('io.kestra.plugin:plugin-git-lib:1.0.0')
+    testImplementation testFixtures('io.kestra.plugin:plugin-git-lib:1.0.2')
 }
 
 /**********************************************************************************************************************\

--- a/src/main/java/io/kestra/plugin/git/SyncFlow.java
+++ b/src/main/java/io/kestra/plugin/git/SyncFlow.java
@@ -126,7 +126,6 @@ public class SyncFlow extends AbstractKestraTask implements RunnableTask<SyncFlo
         GitService gitService = new GitService(this);
 
         String rBranch = runContext.render(this.getBranch()).as(String.class).orElse(null);
-        // TODO(#343): requires plugin-git-lib >= <next release> for GitService.ensureBranchExistsOrFail
         gitService.ensureBranchExistsOrFail(runContext, rBranch, runContext.render(this.failOnMissingBranch).as(Boolean.class).orElse(true));
         Git git = gitService.cloneBranch(runContext, rBranch, Property.ofValue(Boolean.FALSE));
         Path cloneDir = git.getRepository().getWorkTree().toPath();

--- a/src/main/java/io/kestra/plugin/git/SyncFlow.java
+++ b/src/main/java/io/kestra/plugin/git/SyncFlow.java
@@ -104,6 +104,17 @@ public class SyncFlow extends AbstractKestraTask implements RunnableTask<SyncFlo
     @PluginProperty(group = "reliability")
     private Property<Boolean> dryRun = Property.ofValue(Boolean.FALSE);
 
+    @Schema(
+        title = "Fail when the branch does not exist",
+        description = """
+            When true (default), the task fails if `branch` does not exist on the remote.
+            When false, a missing branch silently falls back to the repository's default branch, \
+            which can cause the wrong version of the flow to be synced."""
+    )
+    @Builder.Default
+    @PluginProperty(group = "reliability")
+    private Property<Boolean> failOnMissingBranch = Property.ofValue(Boolean.TRUE);
+
     @Override
     public Output run(RunContext runContext) throws Exception {
 
@@ -114,7 +125,10 @@ public class SyncFlow extends AbstractKestraTask implements RunnableTask<SyncFlo
 
         GitService gitService = new GitService(this);
 
-        Git git = gitService.cloneBranch(runContext, runContext.render(this.getBranch()).as(String.class).orElse(null), Property.ofValue(Boolean.FALSE));
+        String renderedBranch = runContext.render(this.getBranch()).as(String.class).orElse(null);
+        // TODO(#343): requires plugin-git-lib >= <next release> for GitService.ensureBranchExistsOrFail
+        gitService.ensureBranchExistsOrFail(runContext, renderedBranch, runContext.render(this.failOnMissingBranch).as(Boolean.class).orElse(true));
+        Git git = gitService.cloneBranch(runContext, renderedBranch, Property.ofValue(Boolean.FALSE));
         Path cloneDir = git.getRepository().getWorkTree().toPath();
 
         String renderedFlowPath = runContext.render(this.flowPath).as(String.class).orElseThrow();

--- a/src/main/java/io/kestra/plugin/git/SyncFlow.java
+++ b/src/main/java/io/kestra/plugin/git/SyncFlow.java
@@ -125,23 +125,23 @@ public class SyncFlow extends AbstractKestraTask implements RunnableTask<SyncFlo
 
         GitService gitService = new GitService(this);
 
-        String renderedBranch = runContext.render(this.getBranch()).as(String.class).orElse(null);
+        String rBranch = runContext.render(this.getBranch()).as(String.class).orElse(null);
         // TODO(#343): requires plugin-git-lib >= <next release> for GitService.ensureBranchExistsOrFail
-        gitService.ensureBranchExistsOrFail(runContext, renderedBranch, runContext.render(this.failOnMissingBranch).as(Boolean.class).orElse(true));
-        Git git = gitService.cloneBranch(runContext, renderedBranch, Property.ofValue(Boolean.FALSE));
+        gitService.ensureBranchExistsOrFail(runContext, rBranch, runContext.render(this.failOnMissingBranch).as(Boolean.class).orElse(true));
+        Git git = gitService.cloneBranch(runContext, rBranch, Property.ofValue(Boolean.FALSE));
         Path cloneDir = git.getRepository().getWorkTree().toPath();
 
-        String renderedFlowPath = runContext.render(this.flowPath).as(String.class).orElseThrow();
-        Path flowFilePath = cloneDir.resolve(renderedFlowPath);
+        String rFlowPath = runContext.render(this.flowPath).as(String.class).orElseThrow();
+        Path flowFilePath = cloneDir.resolve(rFlowPath);
 
         if (!Files.exists(flowFilePath)) {
-            throw new java.io.FileNotFoundException("Flow file not found at path: " + renderedFlowPath);
+            throw new java.io.FileNotFoundException("Flow file not found at path: " + rFlowPath);
         }
 
         // Build the client only after confirming the file exists, to keep failures fast and clear
         KestraClient kestraClient = kestraClient(runContext);
 
-        String renderedNamespace = runContext.render(this.targetNamespace).as(String.class).orElseThrow();
+        String rNamespace = runContext.render(this.targetNamespace).as(String.class).orElseThrow();
         String flowSource;
         try (InputStream is = Files.newInputStream(flowFilePath)) {
             flowSource = IOUtils.toString(is, StandardCharsets.UTF_8);
@@ -149,12 +149,12 @@ public class SyncFlow extends AbstractKestraTask implements RunnableTask<SyncFlo
 
         // Rewrite the namespace to the target namespace
         Matcher namespaceMatcher = NAMESPACE_FINDER_PATTERN.matcher(flowSource);
-        flowSource = namespaceMatcher.replaceFirst("namespace: " + renderedNamespace);
+        flowSource = namespaceMatcher.replaceFirst("namespace: " + rNamespace);
 
         // Parse the flow id from the (potentially rewritten) YAML
         Matcher idMatcher = FLOW_ID_FINDER_PATTERN.matcher(flowSource);
         if (!idMatcher.find()) {
-            throw new IllegalStateException("Cannot parse flow id from YAML at path: " + renderedFlowPath);
+            throw new IllegalStateException("Cannot parse flow id from YAML at path: " + rFlowPath);
         }
         String flowId = idMatcher.group(1).trim();
 
@@ -173,7 +173,7 @@ public class SyncFlow extends AbstractKestraTask implements RunnableTask<SyncFlo
             // Projected revision: existing + 1, or 1 for a new flow
             int projectedRevision;
             try {
-                FlowWithSource existing = kestraClient.flows().flow(renderedNamespace, flowId, tenantId, false, null, false);
+                FlowWithSource existing = kestraClient.flows().flow(rNamespace, flowId, tenantId, false, null, false);
                 projectedRevision = existing.getRevision() != null ? existing.getRevision() + 1 : 1;
             } catch (ApiException e) {
                 // Flow does not exist yet
@@ -182,7 +182,7 @@ public class SyncFlow extends AbstractKestraTask implements RunnableTask<SyncFlo
 
             result = new FlowWithSource()
                 .id(flowId)
-                .namespace(renderedNamespace)
+                .namespace(rNamespace)
                 .revision(projectedRevision);
         } else {
             // Import the flow
@@ -190,7 +190,7 @@ public class SyncFlow extends AbstractKestraTask implements RunnableTask<SyncFlo
             kestraClient.flows().importFlows(tenantId, true, tempFile);
 
             // Fetch the saved flow to populate the output
-            result = kestraClient.flows().flow(renderedNamespace, flowId, tenantId, false, null, false);
+            result = kestraClient.flows().flow(rNamespace, flowId, tenantId, false, null, false);
         }
 
         git.close();

--- a/src/test/java/io/kestra/plugin/git/SyncFlowTest.java
+++ b/src/test/java/io/kestra/plugin/git/SyncFlowTest.java
@@ -287,6 +287,48 @@ public class SyncFlowTest extends AbstractGitTest {
         assertThat(exception.getMessage(), containsString("non_existent_file.yml"));
     }
 
+    @Test
+    void missingBranch_shouldFailInsteadOfFallingBackToDefaultBranch() throws Exception {
+        // if the fallback bug regresses, the task would clone the default branch and hit this endpoint
+        var importCallCount = new java.util.concurrent.atomic.AtomicInteger(0);
+        var server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/api/v1/" + TENANT_ID + "/flows/import", exchange ->
+        {
+            importCallCount.incrementAndGet();
+            exchange.getRequestBody().readAllBytes();
+            exchange.sendResponseHeaders(200, -1);
+            exchange.close();
+        });
+        server.start();
+
+        try {
+            var kestraUrl = "http://localhost:" + server.getAddress().getPort();
+            SyncFlow task = SyncFlow.builder()
+                .url(Property.ofExpression("{{url}}"))
+                .username(Property.ofExpression("{{pat}}"))
+                .password(Property.ofExpression("{{pat}}"))
+                .branch(Property.ofValue("does-not-exist-on-remote"))
+                .targetNamespace(Property.ofValue(TARGET_NAMESPACE))
+                .flowPath(Property.ofValue("to_clone/_flows/first-flow.yml"))
+                .kestraUrl(Property.ofValue(kestraUrl))
+                .auth(
+                    AbstractKestraTask.Auth.builder()
+                        .username(Property.ofValue("user"))
+                        .password(Property.ofValue("pass"))
+                        .build()
+                )
+                .build();
+
+            assertThrows(
+                IllegalArgumentException.class,
+                () -> task.run(runContext())
+            );
+            assertThat("no flow should have been imported into the target namespace", importCallCount.get(), is(0));
+        } finally {
+            server.stop(0);
+        }
+    }
+
     private io.kestra.core.runners.RunContext runContext() {
         return runContextFactory.of(
             Map.of(


### PR DESCRIPTION
## Summary

Protects `SyncFlow` from silently syncing the **wrong branch**, the `SyncFlow` half of #343.

When `branch` does not exist on the remote, `GitService.cloneBranch` falls back to the repository's default branch (it creates the missing branch locally from the default HEAD). `SyncFlow` then reads `flowPath` from that default-branch tree, so it can silently import the **default branch's version** of the flow into `targetNamespace` while the execution reports SUCCESS. (Unlike `SyncFlows`/`SyncNamespaceFiles`, `SyncFlow` has no bulk delete, so this is silent wrong-content, not data loss.)

This PR:
- adds a `failOnMissingBranch` property (default `true`) to `SyncFlow`, and
- guards the direct `cloneBranch` call with the shared `GitService.ensureBranchExistsOrFail(...)` primitive, so a missing branch now fails loudly instead of falling back.

The bulk-sync tasks (`SyncFlows`, `SyncNamespaceFiles`) are fixed in the shared kernel via `AbstractSyncTask` and are **not** part of this PR.

## Shared-kernel dependency

`GitService.ensureBranchExistsOrFail(...)` ships in **plugin-git-lib 1.0.2** (kestra-io/plugin-git-lib#6). This branch is rebased onto `main` (which already consumes the shared kernel via #342) and bumps the `plugin-git-lib` `api` + `testFixtures` coordinates from `1.0.0` to `1.0.2`. No longer blocked.

## Test plan

- New regression test `SyncFlowTest#missingBranch_shouldFailInsteadOfFallingBackToDefaultBranch` — syncs a non-existent branch and asserts the task throws `IllegalArgumentException` **and** the mock flow-import endpoint receives zero calls (concrete proof no flow was imported). Uses the class's existing real-remote + mock-Kestra-API harness.
- `./gradlew compileJava compileTestJava` passes against `plugin-git-lib:1.0.2`; `./gradlew test` runs in CI.

Related: kestra-io/plugin-git-lib#6 · fixes #343

🤖 Generated with [Claude Code](https://claude.com/claude-code)
