### PR TITLE
fix(push): consume plugin-git-lib 1.0.1 with DELETE_ONLY push mode

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     compileOnly group: "io.kestra", name: "script", version: kestraVersion
 
     // shared Git kernel (also brings jgit and kestra-api-client transitively as `api`)
-    api 'io.kestra.plugin:plugin-git-lib:1.0.1'
+    api 'io.kestra.plugin:plugin-git-lib:1.0.2'
 }
 
 
@@ -103,7 +103,7 @@ dependencies {
     testImplementation "org.testcontainers:junit-jupiter:1.21.4"
 
     // shared Gitea/Kestra-container test scaffolding and mock Kestra API server
-    testImplementation testFixtures('io.kestra.plugin:plugin-git-lib:1.0.1')
+    testImplementation testFixtures('io.kestra.plugin:plugin-git-lib:1.0.2')
 }
 
 /**********************************************************************************************************************\

--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     compileOnly group: "io.kestra", name: "script", version: kestraVersion
 
     // shared Git kernel (also brings jgit and kestra-api-client transitively as `api`)
-    api 'io.kestra.plugin:plugin-git-lib:1.0.0'
+    api 'io.kestra.plugin:plugin-git-lib:1.0.1'
 }
 
 
@@ -103,7 +103,7 @@ dependencies {
     testImplementation "org.testcontainers:junit-jupiter:1.21.4"
 
     // shared Gitea/Kestra-container test scaffolding and mock Kestra API server
-    testImplementation testFixtures('io.kestra.plugin:plugin-git-lib:1.0.0')
+    testImplementation testFixtures('io.kestra.plugin:plugin-git-lib:1.0.1')
 }
 
 /**********************************************************************************************************************\

--- a/src/test/java/io/kestra/plugin/git/PushFlowsTest.java
+++ b/src/test/java/io/kestra/plugin/git/PushFlowsTest.java
@@ -37,6 +37,7 @@ import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.tenant.TenantService;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.core.utils.Rethrow;
+import io.kestra.plugin.git.shared.AbstractPushTask;
 import io.kestra.plugin.git.shared.services.GitService;
 import io.kestra.plugin.git.shared.testkit.AbstractGitTest;
 import io.kestra.plugin.git.shared.testkit.MockKestraApiServer;
@@ -814,6 +815,190 @@ public class PushFlowsTest extends AbstractGitTest {
             );
         } finally {
             this.deleteRemoteBranch(runContext.workingDir().path(), branch);
+        }
+    }
+
+    /**
+     * Pylon #2332 / issue #345, need #2: "push all deletes without also including all changes and all new flows".
+     * With {@code pushMode: DELETE_ONLY} a {@code delete: true} push stages ONLY the removal of a flow deleted from
+     * Kestra; an unrelated change made to another flow must NOT ride along on the commit.
+     */
+    @Test
+    void deleteOnly_pushesOnlyDeletion_leavesUnrelatedModificationOnBranch() throws Exception {
+        String tenantId = TenantService.MAIN_TENANT;
+        String sourceNamespace = IdUtils.create().toLowerCase();
+        String targetNamespace = IdUtils.create().toLowerCase();
+        String branch = IdUtils.create();
+        String gitDirectory = "my-flows";
+
+        FlowWithSource keptFlow = this.createFlow(tenantId, "kept-flow", sourceNamespace);
+        FlowWithSource deletedFlow = this.createFlow(tenantId, "deleted-flow", sourceNamespace);
+
+        PushFlows syncPush = PushFlows.builder()
+            .id("pushFlows")
+            .type(PushFlows.class.getName())
+            .branch(Property.ofExpression("{{branch}}"))
+            .url(Property.ofExpression("{{url}}"))
+            .commitMessage(Property.ofValue("Baseline - both flows"))
+            .username(Property.ofExpression("{{pat}}"))
+            .password(Property.ofExpression("{{pat}}"))
+            .authorEmail(Property.ofExpression("{{email}}"))
+            .authorName(Property.ofExpression("{{name}}"))
+            .sourceNamespace(Property.ofExpression("{{sourceNamespace}}"))
+            .targetNamespace(Property.ofExpression("{{targetNamespace}}"))
+            .gitDirectory(Property.ofExpression("{{gitDirectory}}"))
+            .kestraUrl(Property.ofValue(server.url()))
+            .build();
+
+        try {
+            // 1. Baseline SYNC push of both flows.
+            syncPush.run(runContext(tenantId, repositoryUrl, gitUserEmail, gitUserName, branch, sourceNamespace, targetNamespace, gitDirectory));
+
+            String keptOriginalContent = keptFlow.getSource().replace(sourceNamespace, targetNamespace);
+
+            // 2. Modify the kept flow directly in Kestra (a pending change we do NOT want to push).
+            FlowWithSource keptReloaded = flowRepositoryInterface.findByNamespaceWithSource(tenantId, sourceNamespace).stream()
+                .filter(f -> f.getId().equals(keptFlow.getId()))
+                .findFirst()
+                .orElseThrow();
+            String editedSource = keptReloaded.getSource().replace("Hello from my-task", "CHANGED after baseline");
+            flowRepositoryInterface.update(GenericFlow.fromYaml(tenantId, editedSource).toBuilder().source(editedSource).build(), keptReloaded);
+
+            // 3. Delete the other flow from Kestra.
+            flowRepositoryInterface.delete(deletedFlow);
+
+            // 4. DELETE_ONLY push: stage only the removal of deletedFlow, leaving keptFlow untouched.
+            RunContext deleteOnlyContext = runContext(tenantId, repositoryUrl, gitUserEmail, gitUserName, branch, sourceNamespace, targetNamespace, gitDirectory);
+            PushFlows.Output deleteOnlyOutput = syncPush.toBuilder()
+                .commitMessage(Property.ofValue("Delete only"))
+                .delete(Property.ofValue(true))
+                .pushMode(Property.ofValue(AbstractPushTask.PushMode.DELETE_ONLY))
+                .build()
+                .run(deleteOnlyContext);
+
+            // 5. Verify the branch: deletedFlow gone, keptFlow still holds its ORIGINAL (unmodified) content.
+            Clone clone = Clone.builder()
+                .id("clone")
+                .type(Clone.class.getName())
+                .url(Property.ofValue(repositoryUrl))
+                .username(Property.ofValue(pat))
+                .password(Property.ofValue(pat))
+                .branch(Property.ofValue(branch))
+                .build();
+            Clone.Output cloneOutput = clone.run(runContextFactory.of());
+
+            File deletedFile = new File(Path.of(cloneOutput.getDirectory(), gitDirectory, deletedFlow.getId() + ".yml").toString());
+            assertThat("deleted flow should be removed from Git", deletedFile.exists(), is(false));
+
+            File keptFile = new File(Path.of(cloneOutput.getDirectory(), gitDirectory, keptFlow.getId() + ".yml").toString());
+            assertThat("kept flow should remain on the branch", keptFile.exists(), is(true));
+            String keptContentOnBranch = FileUtils.readFileToString(keptFile, "UTF-8");
+            assertThat("kept flow must keep its original content; the unrelated change must not ride along", keptContentOnBranch, is(keptOriginalContent));
+            assertThat(keptContentOnBranch, not(containsString("CHANGED after baseline")));
+
+            assertDiffs(
+                deleteOnlyContext,
+                deleteOnlyOutput.diffFileUri(),
+                List.of(
+                    Map.of("additions", "+0", "deletions", "-10", "changes", "0", "file", gitDirectory + "/" + deletedFlow.getId() + ".yml")
+                )
+            );
+        } finally {
+            this.deleteRemoteBranch(
+                runContext(tenantId, repositoryUrl, gitUserEmail, gitUserName, branch, sourceNamespace, targetNamespace, gitDirectory).workingDir().path(),
+                branch
+            );
+        }
+    }
+
+    /**
+     * Pylon #2332 / issue #345, need #1: "push a delete of a single flow, ignoring all other". A DELETE_ONLY push
+     * scoped to a single flow id removes only that flow's file; other flows (even ones changed in Kestra) are untouched.
+     */
+    @Test
+    void deleteOnly_singleFlowGlob_deletesOnlyThatFlow() throws Exception {
+        String tenantId = TenantService.MAIN_TENANT;
+        String sourceNamespace = IdUtils.create().toLowerCase();
+        String targetNamespace = IdUtils.create().toLowerCase();
+        String branch = IdUtils.create();
+        String gitDirectory = "my-flows";
+
+        FlowWithSource keptFlow = this.createFlow(tenantId, "kept-flow", sourceNamespace);
+        FlowWithSource deletedFlow = this.createFlow(tenantId, "deleted-flow", sourceNamespace);
+
+        PushFlows syncPush = PushFlows.builder()
+            .id("pushFlows")
+            .type(PushFlows.class.getName())
+            .branch(Property.ofExpression("{{branch}}"))
+            .url(Property.ofExpression("{{url}}"))
+            .commitMessage(Property.ofValue("Baseline - both flows"))
+            .username(Property.ofExpression("{{pat}}"))
+            .password(Property.ofExpression("{{pat}}"))
+            .authorEmail(Property.ofExpression("{{email}}"))
+            .authorName(Property.ofExpression("{{name}}"))
+            .sourceNamespace(Property.ofExpression("{{sourceNamespace}}"))
+            .targetNamespace(Property.ofExpression("{{targetNamespace}}"))
+            .gitDirectory(Property.ofExpression("{{gitDirectory}}"))
+            .kestraUrl(Property.ofValue(server.url()))
+            .build();
+
+        try {
+            // Baseline SYNC push of both flows.
+            syncPush.run(runContext(tenantId, repositoryUrl, gitUserEmail, gitUserName, branch, sourceNamespace, targetNamespace, gitDirectory));
+
+            String keptOriginalContent = keptFlow.getSource().replace(sourceNamespace, targetNamespace);
+
+            // Change the kept flow in Kestra to prove a single-flow delete ignores unrelated pending changes.
+            FlowWithSource keptReloaded = flowRepositoryInterface.findByNamespaceWithSource(tenantId, sourceNamespace).stream()
+                .filter(f -> f.getId().equals(keptFlow.getId()))
+                .findFirst()
+                .orElseThrow();
+            String editedSource = keptReloaded.getSource().replace("Hello from my-task", "CHANGED after baseline");
+            flowRepositoryInterface.update(GenericFlow.fromYaml(tenantId, editedSource).toBuilder().source(editedSource).build(), keptReloaded);
+
+            // Delete a single flow from Kestra and push only that deletion, scoped by flow id.
+            flowRepositoryInterface.delete(deletedFlow);
+
+            RunContext deleteOnlyContext = runContext(tenantId, repositoryUrl, gitUserEmail, gitUserName, branch, sourceNamespace, targetNamespace, gitDirectory);
+            PushFlows.Output deleteOnlyOutput = syncPush.toBuilder()
+                .commitMessage(Property.ofValue("Delete single flow"))
+                .flows(deletedFlow.getId())
+                .delete(Property.ofValue(true))
+                .pushMode(Property.ofValue(AbstractPushTask.PushMode.DELETE_ONLY))
+                .build()
+                .run(deleteOnlyContext);
+
+            Clone clone = Clone.builder()
+                .id("clone")
+                .type(Clone.class.getName())
+                .url(Property.ofValue(repositoryUrl))
+                .username(Property.ofValue(pat))
+                .password(Property.ofValue(pat))
+                .branch(Property.ofValue(branch))
+                .build();
+            Clone.Output cloneOutput = clone.run(runContextFactory.of());
+
+            File deletedFile = new File(Path.of(cloneOutput.getDirectory(), gitDirectory, deletedFlow.getId() + ".yml").toString());
+            assertThat("targeted flow should be removed from Git", deletedFile.exists(), is(false));
+
+            File keptFile = new File(Path.of(cloneOutput.getDirectory(), gitDirectory, keptFlow.getId() + ".yml").toString());
+            assertThat("other flow should be untouched", keptFile.exists(), is(true));
+            String keptContentOnBranch = FileUtils.readFileToString(keptFile, "UTF-8");
+            assertThat("other flow must keep its original content", keptContentOnBranch, is(keptOriginalContent));
+            assertThat(keptContentOnBranch, not(containsString("CHANGED after baseline")));
+
+            assertDiffs(
+                deleteOnlyContext,
+                deleteOnlyOutput.diffFileUri(),
+                List.of(
+                    Map.of("additions", "+0", "deletions", "-10", "changes", "0", "file", gitDirectory + "/" + deletedFlow.getId() + ".yml")
+                )
+            );
+        } finally {
+            this.deleteRemoteBranch(
+                runContext(tenantId, repositoryUrl, gitUserEmail, gitUserName, branch, sourceNamespace, targetNamespace, gitDirectory).workingDir().path(),
+                branch
+            );
         }
     }
 

--- a/src/test/java/io/kestra/plugin/git/PushFlowsTest.java
+++ b/src/test/java/io/kestra/plugin/git/PushFlowsTest.java
@@ -850,6 +850,9 @@ public class PushFlowsTest extends AbstractGitTest {
             .kestraUrl(Property.ofValue(server.url()))
             .build();
 
+        // The DELETE_ONLY push clones into this context's working dir; it is what the finally block uses for cleanup.
+        RunContext deleteOnlyContext = runContext(tenantId, repositoryUrl, gitUserEmail, gitUserName, branch, sourceNamespace, targetNamespace, gitDirectory);
+
         try {
             // 1. Baseline SYNC push of both flows.
             syncPush.run(runContext(tenantId, repositoryUrl, gitUserEmail, gitUserName, branch, sourceNamespace, targetNamespace, gitDirectory));
@@ -868,7 +871,6 @@ public class PushFlowsTest extends AbstractGitTest {
             flowRepositoryInterface.delete(deletedFlow);
 
             // 4. DELETE_ONLY push: stage only the removal of deletedFlow, leaving keptFlow untouched.
-            RunContext deleteOnlyContext = runContext(tenantId, repositoryUrl, gitUserEmail, gitUserName, branch, sourceNamespace, targetNamespace, gitDirectory);
             PushFlows.Output deleteOnlyOutput = syncPush.toBuilder()
                 .commitMessage(Property.ofValue("Delete only"))
                 .delete(Property.ofValue(true))
@@ -904,10 +906,10 @@ public class PushFlowsTest extends AbstractGitTest {
                 )
             );
         } finally {
-            this.deleteRemoteBranch(
-                runContext(tenantId, repositoryUrl, gitUserEmail, gitUserName, branch, sourceNamespace, targetNamespace, gitDirectory).workingDir().path(),
-                branch
-            );
+            try {
+                this.deleteRemoteBranch(deleteOnlyContext.workingDir().path(), branch);
+            } catch (Exception ignored) {
+            }
         }
     }
 
@@ -942,6 +944,9 @@ public class PushFlowsTest extends AbstractGitTest {
             .kestraUrl(Property.ofValue(server.url()))
             .build();
 
+        // The DELETE_ONLY push clones into this context's working dir; it is what the finally block uses for cleanup.
+        RunContext deleteOnlyContext = runContext(tenantId, repositoryUrl, gitUserEmail, gitUserName, branch, sourceNamespace, targetNamespace, gitDirectory);
+
         try {
             // Baseline SYNC push of both flows.
             syncPush.run(runContext(tenantId, repositoryUrl, gitUserEmail, gitUserName, branch, sourceNamespace, targetNamespace, gitDirectory));
@@ -959,7 +964,6 @@ public class PushFlowsTest extends AbstractGitTest {
             // Delete a single flow from Kestra and push only that deletion, scoped by flow id.
             flowRepositoryInterface.delete(deletedFlow);
 
-            RunContext deleteOnlyContext = runContext(tenantId, repositoryUrl, gitUserEmail, gitUserName, branch, sourceNamespace, targetNamespace, gitDirectory);
             PushFlows.Output deleteOnlyOutput = syncPush.toBuilder()
                 .commitMessage(Property.ofValue("Delete single flow"))
                 .flows(deletedFlow.getId())
@@ -995,10 +999,10 @@ public class PushFlowsTest extends AbstractGitTest {
                 )
             );
         } finally {
-            this.deleteRemoteBranch(
-                runContext(tenantId, repositoryUrl, gitUserEmail, gitUserName, branch, sourceNamespace, targetNamespace, gitDirectory).workingDir().path(),
-                branch
-            );
+            try {
+                this.deleteRemoteBranch(deleteOnlyContext.workingDir().path(), branch);
+            } catch (Exception ignored) {
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Completes the OSS side of #345. The fix itself lives in the shared kernel — `AbstractPushTask` in [plugin-git-lib](https://github.com/kestra-io/plugin-git-lib) ([#8](https://github.com/kestra-io/plugin-git-lib/pull/8), first released as **1.0.1**). This PR:

- bumps the `plugin-git-lib` pin `1.0.0` → **`1.0.2`** in `build.gradle` (both the `api` and `testFixtures` coordinates), pulling in the new `pushMode` property (`SYNC` default, `DELETE_ONLY`);
- adds two end-to-end `PushFlows` tests at the OSS surface, one per need in the originating support report (Pylon #2332).

## Why 1.0.2 rather than 1.0.1

`DELETE_ONLY` shipped in lib 1.0.1, but 1.0.2 is already released and is a **strict superset** — it still carries the `DELETE_ONLY` push mode this PR is built around, and additionally brings two more shared-kernel changes into the OSS plugin:

- **[#6](https://github.com/kestra-io/plugin-git-lib/pull/6)** — sync tasks now fail when the requested branch does not exist on the remote;
- **[#7](https://github.com/kestra-io/plugin-git-lib/pull/7)** — call an unauthenticated Kestra API when `auth.auto` is disabled.

Pinning to the latest released lib keeps OSS from trailing behind and needing an immediate follow-up bump. The two new tests here still exercise only the `DELETE_ONLY` surface.

## Why

Before the fix, `PushFlows` with `delete: true` always re-wrote and re-staged every flow matching `flows`, so a delete-only intent dragged along unrelated modified/new flows. `pushMode: DELETE_ONLY` stages only the removals of flows no longer present in Kestra, writing/staging nothing else.

## Coverage vs the customer's two needs (Pylon #2332)

1. **"Push a delete of a single flow, ignoring all others"** → `deleteOnly_singleFlowGlob_deletesOnlyThatFlow`: a `DELETE_ONLY` push scoped to one flow id removes only that file; another flow — even one changed in Kestra — is untouched.
2. **"Push all deletes without also including all changes and all new flows"** → `deleteOnly_pushesOnlyDeletion_leavesUnrelatedModificationOnBranch` (the exact issue repro): after modifying flow `a` and deleting flow `b` in Kestra, a `DELETE_ONLY` push commits only the deletion of `b`; `a`'s pending change does not ride along.

## Test plan

- [x] `./gradlew compileTestJava` — green against the released lib (resolved from Maven Central).
- [ ] The two new tests are Gitea/PAT-backed (like the rest of `PushFlowsTest`) and run in CI, not in the local sandbox.

## Follow-up

- `plugin-ee-git` needs the same mechanical bump to **1.0.2** so the Enterprise push tasks pick up the mode (and #6/#7).

Closes #345

🤖 Generated with [Claude Code](https://claude.com/claude-code)
