### PR TITLE
fix(git): reword misleading 404 message in NamespaceSync's namespace check

### DIFF
--- a/src/main/java/io/kestra/plugin/git/NamespaceSync.java
+++ b/src/main/java/io/kestra/plugin/git/NamespaceSync.java
@@ -250,7 +250,17 @@ public class NamespaceSync extends AbstractCloningTask implements RunnableTask<N
             kestraClient.namespaces().namespace(rNamespace, tenantId);
         } catch (ApiException e) {
             if (e.getCode() == 404) {
-                throw new IllegalArgumentException("The namespace does not exist in the '" + tenantId + "' tenant.");
+                var rKestraUrl = runContext.render(this.kestraUrl).as(String.class).orElse(null);
+                throw new IllegalArgumentException(
+                    "The Kestra API returned 404 for namespace '" + rNamespace + "' in tenant '" + tenantId + "'. This usually means "
+                        + "either the namespace does not exist yet, or the `kestraUrl` this task resolved to does not point at the Kestra "
+                        + "webserver API (resolved `kestraUrl`: " + (rKestraUrl != null ? rKestraUrl
+                            : "not set on the task — falling back to "
+                                + "`kestra.tasks.sdk.authentication.url`, then `kestra.url`, then `http://localhost:8080`")
+                        + "). "
+                        + "Create the namespace first, or fix the `kestraUrl` task property / `kestra.tasks.sdk.authentication.url` / "
+                        + "`kestra.url` configuration."
+                );
             }
             throw e;
         }

--- a/src/main/java/io/kestra/plugin/git/PushFlows.java
+++ b/src/main/java/io/kestra/plugin/git/PushFlows.java
@@ -258,7 +258,9 @@ public class PushFlows extends AbstractPushTask<PushFlows.Output> {
         } catch (IOException e) {
             throw new KestraRuntimeException("Failed to export flows from Kestra for namespace " + namespace, e);
         } catch (ApiException e) {
-            throw new KestraRuntimeException("Failed to export flows from Kestra for namespace " + namespace, e);
+            throw new KestraRuntimeException(
+                "Failed to export flows from Kestra for namespace " + namespace + " (HTTP " + e.getCode() + "): " + e.getMessage(), e
+            );
         }
     }
 

--- a/src/main/java/io/kestra/plugin/git/SyncFlow.java
+++ b/src/main/java/io/kestra/plugin/git/SyncFlow.java
@@ -175,7 +175,14 @@ public class SyncFlow extends AbstractKestraTask implements RunnableTask<SyncFlo
                 FlowWithSource existing = kestraClient.flows().flow(rNamespace, flowId, tenantId, false, null, false);
                 projectedRevision = existing.getRevision() != null ? existing.getRevision() + 1 : 1;
             } catch (ApiException e) {
-                // Flow does not exist yet
+                if (e.getCode() != 404) {
+                    // Only 404 means "flow does not exist yet"; any other status is a real API/permissions
+                    // failure, surfaced here so a misconfigured kestraUrl isn't silently reported as revision 1.
+                    runContext.logger().warn(
+                        "Failed to fetch existing flow {}.{} from the Kestra API (status {}): {} — assuming it does not exist yet for revision projection",
+                        rNamespace, flowId, e.getCode(), e.getMessage()
+                    );
+                }
                 projectedRevision = 1;
             }
 

--- a/src/main/java/io/kestra/plugin/git/SyncFlows.java
+++ b/src/main/java/io/kestra/plugin/git/SyncFlows.java
@@ -387,7 +387,9 @@ public class SyncFlows extends AbstractSyncTask<Flow, SyncFlows.Output> {
         } catch (IOException e) {
             throw new KestraRuntimeException("Failed to export flows from Kestra for namespace " + namespace, e);
         } catch (ApiException e) {
-            throw new KestraRuntimeException("Failed to export flows from Kestra for namespace " + namespace, e);
+            throw new KestraRuntimeException(
+                "Failed to export flows from Kestra for namespace " + namespace + " (HTTP " + e.getCode() + "): " + e.getMessage(), e
+            );
         }
     }
 

--- a/src/test/java/io/kestra/plugin/git/NamespaceSyncTest.java
+++ b/src/test/java/io/kestra/plugin/git/NamespaceSyncTest.java
@@ -3,6 +3,7 @@ package io.kestra.plugin.git;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.InetSocketAddress;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -15,6 +16,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.sun.net.httpserver.HttpServer;
 
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.flows.Flow;
@@ -37,6 +39,7 @@ import jakarta.inject.Inject;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.*;
 
 @KestraTest
@@ -239,6 +242,45 @@ public class NamespaceSyncTest extends AbstractGitTest {
 
         assertTrue(Files.exists(base.resolve("flows/" + flowId + ".yaml")));
         assertFalse(Files.exists(base.resolve("flows/" + draftFlowId + ".yaml")));
+    }
+
+    @Test
+    void namespaceCheck_404_namesBothCausesAndResolvedKestraUrl() throws Exception {
+        // The mock server used by every other test never 404s on GET /namespaces/{id} (as real OSS Kestra
+        // doesn't either), so a dedicated server is needed here to force the 404 branch.
+        var server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/api/v1/" + TENANT_ID + "/namespaces/" + NAMESPACE, exchange ->
+        {
+            exchange.getRequestBody().readAllBytes();
+            exchange.sendResponseHeaders(404, -1);
+            exchange.close();
+        });
+        server.start();
+
+        try {
+            var kestraUrl = "http://localhost:" + server.getAddress().getPort();
+            NamespaceSync task = NamespaceSync.builder()
+                .url(Property.ofExpression("{{url}}"))
+                .username(Property.ofExpression("{{pat}}"))
+                .password(Property.ofExpression("{{pat}}"))
+                .branch(Property.ofExpression("{{branch}}"))
+                .namespace(Property.ofExpression("{{namespace}}"))
+                .kestraUrl(Property.ofValue(kestraUrl))
+                .build();
+
+            IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> task.run(runContext())
+            );
+
+            assertThat(exception.getMessage(), containsString(NAMESPACE));
+            assertThat(exception.getMessage(), containsString(TENANT_ID));
+            assertThat(exception.getMessage(), containsString(kestraUrl));
+            assertThat(exception.getMessage(), containsString("does not exist yet"));
+            assertThat(exception.getMessage(), containsString("kestraUrl"));
+        } finally {
+            server.stop(0);
+        }
     }
 
     private RunContext runContext() {

--- a/src/test/java/io/kestra/plugin/git/SyncFlowsTest.java
+++ b/src/test/java/io/kestra/plugin/git/SyncFlowsTest.java
@@ -188,6 +188,18 @@ public class SyncFlowsTest extends AbstractGitTest {
         flows = flowRepositoryInterface.findAllForAllTenants();
         assertThat(flows, hasSize(6));
 
+        // Guard: 'another.namespace' is a sibling of 'my.namespace' (not a descendant) — it must never be
+        // returned by the sync or considered for deletion, even with includeChildNamespaces=true and delete=true.
+        // If the namespace filter serialization ever regressed, the mock would return every flow unfiltered and
+        // this flow would become a false deletion candidate.
+        List<Flow> siblingNamespaceFlows = flowRepositoryInterface.findByNamespace(TENANT_ID, "another.namespace");
+        assertThat(siblingNamespaceFlows, hasSize(1));
+        assertThat(siblingNamespaceFlows.getFirst().getId(), is("unpresent-on-git-flow"));
+        assertThat(
+            IOUtils.toString(runContext.storage().getFile(syncOutput.diffFileUri()), StandardCharsets.UTF_8),
+            not(containsString("unpresent-on-git-flow"))
+        );
+
         RunContext cloneRunContext = runContextFactory.of();
         Clone.builder()
             .url(Property.ofValue(repositoryUrl))


### PR DESCRIPTION
## Summary

- Reworded `NamespaceSync`'s namespace-existence pre-check: OSS Kestra's `GET /namespaces/{id}` never returns 404 for any id (verified against a live 2.0.0 OSS instance), so the old "the namespace does not exist" message was unreachable in a healthy deployment and mislabeled the real cause whenever it did fire. The new message names both plausible causes (namespace missing, or a `kestraUrl` that doesn't resolve to the Kestra webserver API) and includes the task's resolved `kestraUrl` (or the fallback chain description when unset).
- Tightened three other `ApiException` catch sites that swallowed the HTTP status/body behind a generic message, in a minimal, inline way (no shared helper introduced): `SyncFlows`/`PushFlows` flow export now include `HTTP <status>: <message>` in the wrapped exception, and `SyncFlow`'s dry-run revision lookup now logs a warning naming the status/message for any non-404 failure instead of silently assuming the flow doesn't exist.
- Added a regression test locking down the new 404 message (`NamespaceSyncTest`), using a dedicated local `HttpServer` since the shared `MockKestraApiServer` never 404s on namespace lookups (mirroring real OSS behavior).
- Strengthened `SyncFlowsTest.defaultCase_WithDelete` with an explicit guard: a flow in a sibling namespace (`another.namespace`, not a descendant of the target) must never be returned by the sync or considered for deletion, even with `delete: true` and `includeChildNamespaces: true` — this is the regression guard for the namespace-filter path also confirmed working end-to-end during the manual OSS reproduction (`EQUALS=system` → empty export, `EQUALS=tutorial` → full export).

**Scope note:** this is the OSS-only slice of the fix for the linked issue. The shared-kernel diagnostics helper (wrapping `ApiException` with URL/method/status/body, to be reused consistently across all catch sites without duplicating the formatting) is intentionally deferred to a follow-up `plugin-git-lib` PR + release, per the approved plan. This PR does not bump the `plugin-git-lib` version.

part-of: https://github.com/kestra-io/kestra/issues/19181

## Test plan

- [x] `rtk test ./gradlew test` passes (90/90, including the new `NamespaceSyncTest` and strengthened `SyncFlowsTest` cases) — run locally with a local Gitea fixture (`.github/setup-unit.sh`) and a personal GitHub token exported as `GH_PERSONAL_TOKEN`
- [ ] `./gradlew shadowJar` builds
- [ ] Manually trigger `NamespaceSync` against a Kestra instance with a deliberately wrong `kestraUrl` and confirm the new message names both causes and shows the resolved URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
*[View as Artifact](https://claude.ai/code/artifact/9cca80fe-ff60-44ec-8ecf-02238b873961)*